### PR TITLE
#53 Add support for cashing browser session to avoid having write username password each time a token should be refreshed

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/dever-labs/devcontainers/frontend-dev:latest
+
+# The base image runs `minikube status || minikube start --driver=docker` as a
+# postStartCommand. Postly doesn't use Kubernetes, and the amd64 minikube binary
+# fails on ARM hosts. Replace it with a no-op stub so the lifecycle hook exits cleanly.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/minikube && chmod +x /usr/local/bin/minikube
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,22 @@
 {
   // Postly dev environment — uses the shared dever-labs frontend-dev image.
-  // The image includes: Node.js LTS, Git, GitHub CLI, GitHub Copilot, Claude Code.
+  // The image includes: Node.js LTS, Git, GitHub CLI, Claude Code.
+  // The Dockerfile strips the base image's minikube postStartCommand (not needed for Postly).
   // Rebuild the container after changes: Dev Containers: Rebuild Container.
   "name": "postly",
-  "image": "ghcr.io/dever-labs/devcontainers/frontend-dev:latest",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/npm-package:1": {
+      "package": "@github/copilot",
+      "version": "latest"
+    }
+  },
 
   // Install project dependencies on first container creation.
-  // Copilot CLI and gh-copilot extension are pre-installed in the base image.
   "postCreateCommand": "npm install",
-
-  // Override the shared image's postStartCommand (minikube) — not needed for Postly.
-  "postStartCommand": "true",
 
   "remoteEnv": {
     "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,16 +65,27 @@ test(ipc): cover SSL flag forwarding
 
 ### Rules (enforced by commitlint)
 
-- Subject line **≤ 72 characters**
+- Subject line **≤ 72 characters** — **HARD LIMIT, CI will reject anything longer**
 - Subject line **no trailing period**
 - **No `WIP` commits** merged to main
 - Body lines **≤ 100 characters**
+
+### Auto-generation rules (Copilot commit message generation)
+
+When generating a commit message automatically, you **must**:
+
+1. **Count the subject line characters before finalising.** If it would exceed 72, shorten it — never exceed 72 under any circumstance.
+2. **Move detail to the body, never the subject.** Phrases like "to verify X", "in order to Y", "by doing Z", "which ensures W" belong in the body, not the subject line.
+3. **Stop at the object, not the purpose.** `test(oauth): add session persistence tests` is correct. `test(oauth): add session persistence tests to verify token refresh behavior` is too long and wrong.
+4. **Prefer omitting the scope over truncating mid-word.** If `type(scope): description` is too long, try dropping the scope before shortening the description.
+
+Quick mental check before finalising: `type(scope): description` — count the characters. If > 72, cut.
 
 ### Good examples
 
 ```
 feat(ssl): propagate ssl-verification setting into oauth token requests
-fix(oauth): use unique session partition per auth attempt to avoid shared cookies
+fix(oauth): use unique session partition per auth attempt
 security: disable rejectUnauthorized only when user explicitly opts out
 docs: document conventional commit rules in CONTRIBUTING.md
 chore(deps): add selfsigned devDependency for ssl integration tests
@@ -85,10 +96,12 @@ ci: add commitlint check to pull-request workflow
 ### Bad examples — will be rejected
 
 ```
-Fixed bug                        # no type
-feat: add new thing.             # trailing period
-WIP: experimenting               # WIP not allowed
-FEAT: add thing                  # type must be lowercase
+Fixed bug                                           # no type
+feat: add new thing.                                # trailing period
+WIP: experimenting                                  # WIP not allowed
+FEAT: add thing                                     # type must be lowercase
+test(e2e): add OAuth session persistence tests to verify token refresh behavior  # > 72 chars
+feat(oauth): add integration tests to ensure browser session is preserved        # > 72 chars
 ```
 
 ---

--- a/e2e/oauth-session.spec.ts
+++ b/e2e/oauth-session.spec.ts
@@ -1,0 +1,289 @@
+/**
+ * OAuth session persistence E2E tests
+ *
+ * Verifies that the browser session (cookies, IDP state) used during an OAuth
+ * authorization_code flow is preserved between auth attempts so the user is not
+ * re-prompted to log in every time a token needs refreshing.
+ *
+ * Architecture:
+ *  - Mockly handles the token endpoint (POST /oauth2/token) — real HTTP server,
+ *    call counts, scenario support.
+ *  - A minimal inline Node.js server handles the authorization endpoint. It
+ *    echoes back the `state` query param and sets an IDP session cookie, which
+ *    is what we need to test persistence. Mockly can't do this because it has
+ *    no query-param template syntax.
+ *
+ * Requires a built app (`npm run build` before `npm run test:e2e`)
+ * and the Mockly binary at `bin/mockly` (`node scripts/download-mockly.mjs`).
+ */
+import { test, expect } from './fixtures'
+import http from 'http'
+import type { AddressInfo } from 'net'
+import { MocklyServer } from '../src/main/services/__tests__/helpers/mockly'
+
+// ─── Auth server ─────────────────────────────────────────────────────────────
+
+interface AuthServer {
+  /** Full URL of the /authorize endpoint. */
+  url: string
+  /** Origin (scheme + host + port) — used to scope cookie lookups. */
+  origin: string
+  stop: () => void
+}
+
+/**
+ * Starts a minimal HTTP server that acts as an IDP authorization endpoint.
+ * On every GET it:
+ *  1. Reads `redirect_uri` and `state` from the query params.
+ *  2. Sets an `idp-session` cookie (simulating the IDP creating a server-side session).
+ *  3. Responds with 302 → redirect_uri?code=e2e-auth-code&state=<original-state>.
+ *
+ * Mockly handles everything else (token endpoint); this server exists solely
+ * because Mockly has no query-param template to echo `state` back in a redirect.
+ */
+function startAuthServer(): Promise<AuthServer> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      try {
+        const url = new URL(req.url!, 'http://127.0.0.1')
+        const redirectUri = url.searchParams.get('redirect_uri') ?? ''
+        const state      = url.searchParams.get('state') ?? ''
+        const callback   = new URL(redirectUri)
+        callback.searchParams.set('code', 'e2e-auth-code')
+        callback.searchParams.set('state', state)
+        res.writeHead(302, {
+          Location:   callback.toString(),
+          // Cookie that simulates the IDP maintaining a server-side session.
+          // This is what must survive across auth attempts with the persist: partition fix.
+          'Set-Cookie': 'idp-session=active; Path=/',
+        })
+      } catch {
+        res.writeHead(500)
+      }
+      res.end()
+    })
+
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo
+      resolve({
+        url:    `http://127.0.0.1:${port}/authorize`,
+        origin: `http://127.0.0.1:${port}`,
+        stop:   () => server.close(),
+      })
+    })
+  })
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+let mockly:     MocklyServer
+let authServer: AuthServer
+
+const REDIRECT_URI = 'http://localhost:19999/callback'
+const MOCK_TOKEN_ID = 'oauth2-token'
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('OAuth session persistence', () => {
+  test.beforeAll(async () => {
+    // Start Mockly for the token endpoint.
+    mockly = await MocklyServer.create()
+    await mockly.addMock({
+      id: MOCK_TOKEN_ID,
+      request: { method: 'POST', path: '/oauth2/token' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          access_token:  'e2e-access-token',
+          token_type:    'Bearer',
+          expires_in:    3600,
+          refresh_token: 'e2e-refresh-token',
+          scope:         'read',
+        }),
+      },
+    })
+
+    authServer = await startAuthServer()
+  })
+
+  test.afterAll(async () => {
+    authServer.stop()
+    await mockly.stop()
+  })
+
+  // Reset Mockly call counters and clear test partitions before each test so
+  // counts and cookies from a previous test don't carry over.
+  test.beforeEach(async ({ electronApp }) => {
+    await fetch(`${mockly.apiBase}/api/calls/http/${MOCK_TOKEN_ID}`, { method: 'DELETE' })
+    await electronApp.evaluate(async ({ session }) => {
+      // Clear any leftover cookies from the e2e test partitions.
+      const prefixes = ['persist:oauth-e2e-', 'persist:oauth-ssl-disabled-e2e-']
+      const allSessions = [
+        'persist:oauth-e2e-ssl-a',
+        'persist:oauth-e2e-ssl-b',
+        'persist:oauth-e2e-config-a',
+        'persist:oauth-e2e-config-b',
+      ]
+      await Promise.all(allSessions.map((p) => session.fromPartition(p).clearStorageData()))
+      void prefixes // referenced to avoid TS unused-var warning
+    })
+  })
+
+  // ── Full flow ────────────────────────────────────────────────────────────
+
+  test('completes the authorization_code flow end-to-end via Mockly IDP', async ({ window }) => {
+    const configId = await window.evaluate(
+      async (args: { name: string; grantType: string; clientId: string; tokenUrl: string; authUrl: string; redirectUri: string; scopes: string }) => {
+        const res = await window.api.oauth.configs.create(args)
+        return (res as { data: { id: string } }).data.id
+      },
+      {
+        name: 'E2E Full Flow', grantType: 'authorization_code', clientId: 'e2e-client',
+        tokenUrl: `${mockly.httpBase}/oauth2/token`, authUrl: authServer.url,
+        redirectUri: REDIRECT_URI, scopes: 'read',
+      }
+    )
+
+    const result = await window.evaluate(async (id: string) => {
+      return window.api.oauth.authorize({ configId: id })
+    }, configId)
+
+    expect((result as { data: { accessToken: string; tokenType: string } }).data.accessToken).toBe('e2e-access-token')
+    expect((result as { data: { accessToken: string; tokenType: string } }).data.tokenType).toBe('Bearer')
+
+    // Confirm Mockly received exactly one token exchange.
+    const calls = await fetch(`${mockly.apiBase}/api/calls/http/${MOCK_TOKEN_ID}`).then((r) => r.json())
+    expect(calls.count).toBe(1)
+
+    await window.evaluate(async (id: string) => { await window.api.oauth.configs.delete({ id }) }, configId)
+  })
+
+  // ── Session persistence ───────────────────────────────────────────────────
+
+  test('IDP session cookie set during first auth is present before second auth', async ({ window, electronApp }) => {
+    // The auth server sets `idp-session=active` on every authorize redirect.
+    // After auth #1 the cookie must be in the persist: partition.
+    // After auth #2 it must still be there — proving the session was reused,
+    // not discarded.  Before the fix each auth got a fresh ephemeral session
+    // and the cookie was lost.
+
+    const configId = await window.evaluate(
+      async (args: { name: string; grantType: string; clientId: string; tokenUrl: string; authUrl: string; redirectUri: string; scopes: string }) => {
+        const res = await window.api.oauth.configs.create(args)
+        return (res as { data: { id: string } }).data.id
+      },
+      {
+        name: 'E2E Persistence', grantType: 'authorization_code', clientId: 'e2e-client',
+        tokenUrl: `${mockly.httpBase}/oauth2/token`, authUrl: authServer.url,
+        redirectUri: REDIRECT_URI, scopes: 'read',
+      }
+    )
+
+    // Auth attempt #1.
+    await window.evaluate(async (id: string) => { await window.api.oauth.authorize({ configId: id }) }, configId)
+
+    // Cookie must be in the session partition after the first auth.
+    const cookiesAfterFirst = await electronApp.evaluate(
+      async ({ session }, id: string) => session.fromPartition(`persist:oauth-${id}`).cookies.get({ name: 'idp-session' }),
+      configId
+    )
+    expect(cookiesAfterFirst).toHaveLength(1)
+    expect(cookiesAfterFirst[0].value).toBe('active')
+
+    // Auth attempt #2 — reuses the same partition.
+    await window.evaluate(async (id: string) => { await window.api.oauth.authorize({ configId: id }) }, configId)
+
+    // Cookie must still be present — not wiped by the second auth.
+    const cookiesAfterSecond = await electronApp.evaluate(
+      async ({ session }, id: string) => session.fromPartition(`persist:oauth-${id}`).cookies.get({ name: 'idp-session' }),
+      configId
+    )
+    expect(cookiesAfterSecond).toHaveLength(1)
+    expect(cookiesAfterSecond[0].value).toBe('active')
+
+    // Token endpoint was called twice — once per auth attempt.
+    const calls = await fetch(`${mockly.apiBase}/api/calls/http/${MOCK_TOKEN_ID}`).then((r) => r.json())
+    expect(calls.count).toBe(2)
+
+    await window.evaluate(async (id: string) => {
+      await window.api.oauth.clearToken({ configId: id })
+      await window.api.oauth.configs.delete({ id })
+    }, configId)
+  })
+
+  // ── Mockly scenarios ─────────────────────────────────────────────────────
+
+  test('surfaces the provider error when the token endpoint returns 503', async ({ window }) => {
+    // Register a separate mock for the "down" path so it does not interfere with
+    // the main oauth2-token mock used by other tests.
+    await mockly.addMock({
+      id: 'oauth2-token-down',
+      request: { method: 'POST', path: '/oauth2/token-down' },
+      response: {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'temporarily_unavailable', error_description: 'Auth server down' }),
+      },
+    })
+
+    const configId = await window.evaluate(
+      async (args: { name: string; grantType: string; clientId: string; tokenUrl: string; authUrl: string; redirectUri: string; scopes: string }) => {
+        const res = await window.api.oauth.configs.create(args)
+        return (res as { data: { id: string } }).data.id
+      },
+      {
+        name: 'E2E Error Test', grantType: 'authorization_code', clientId: 'e2e-client',
+        tokenUrl: `${mockly.httpBase}/oauth2/token-down`, authUrl: authServer.url,
+        redirectUri: REDIRECT_URI, scopes: 'read',
+      }
+    )
+
+    const result = await window.evaluate(async (id: string) => {
+      return window.api.oauth.authorize({ configId: id })
+    }, configId)
+
+    expect((result as { error: string }).error).toContain('503')
+
+    await mockly.deleteMock('oauth2-token-down')
+    await window.evaluate(async (id: string) => { await window.api.oauth.configs.delete({ id }) }, configId)
+  })
+
+  // ── Session isolation ─────────────────────────────────────────────────────
+
+  test('SSL-disabled config session is isolated from the SSL-enabled session', async ({ electronApp }) => {
+    const id = 'e2e-ssl-a'
+    const { enabledCookies, disabledCookies } = await electronApp.evaluate(
+      async ({ session }, id: string) => {
+        await session.fromPartition(`persist:oauth-${id}`).cookies.set({
+          url: 'https://idp.example.com', name: 'sid', value: 'ssl-on',
+        })
+        return {
+          enabledCookies:  await session.fromPartition(`persist:oauth-${id}`).cookies.get({ name: 'sid' }),
+          disabledCookies: await session.fromPartition(`persist:oauth-ssl-disabled-${id}`).cookies.get({ name: 'sid' }),
+        }
+      },
+      id
+    )
+
+    expect(enabledCookies).toHaveLength(1)
+    expect(disabledCookies).toHaveLength(0)
+  })
+
+  test('different OAuth configs have completely isolated sessions', async ({ electronApp }) => {
+    const { cookiesA, cookiesB } = await electronApp.evaluate(async ({ session }) => {
+      await session.fromPartition('persist:oauth-e2e-config-a').cookies.set({
+        url: 'https://idp.example.com', name: 'sid', value: 'config-a',
+      })
+      return {
+        cookiesA: await session.fromPartition('persist:oauth-e2e-config-a').cookies.get({ name: 'sid' }),
+        cookiesB: await session.fromPartition('persist:oauth-e2e-config-b').cookies.get({ name: 'sid' }),
+      }
+    })
+
+    expect(cookiesA).toHaveLength(1)
+    expect(cookiesA[0].value).toBe('config-a')
+    expect(cookiesB).toHaveLength(0)
+  })
+})

--- a/e2e/oauth-session.spec.ts
+++ b/e2e/oauth-session.spec.ts
@@ -13,13 +13,27 @@
  *    is what we need to test persistence. Mockly can't do this because it has
  *    no query-param template syntax.
  *
- * Requires a built app (`npm run build` before `npm run test:e2e`)
- * and the Mockly binary at `bin/mockly` (`node scripts/download-mockly.mjs`).
+ * Requires a built app (`npm run build` before `npm run test:e2e`).
+ * The Mockly binary is downloaded automatically by `npm run test:e2e`
+ * via `node scripts/download-mockly.mjs`.  If the binary is missing when
+ * tests run directly with `playwright test`, all tests in this file are
+ * skipped with a descriptive message.
  */
 import { test, expect } from './fixtures'
 import http from 'http'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
 import type { AddressInfo } from 'net'
 import { MocklyServer } from '../src/main/services/__tests__/helpers/mockly'
+
+// ─── Binary guard ─────────────────────────────────────────────────────────────
+// Skip the entire suite with a clear message when the Mockly binary is absent.
+// In normal usage `npm run test:e2e` downloads it automatically via
+// `node scripts/download-mockly.mjs` before Playwright runs.
+
+const binName = process.platform === 'win32' ? 'mockly.exe' : 'mockly'
+const mocklyBinPath = resolve(__dirname, '..', 'bin', binName)
+const mocklyAvailable = existsSync(mocklyBinPath)
 
 // ─── Auth server ─────────────────────────────────────────────────────────────
 
@@ -86,6 +100,13 @@ const MOCK_TOKEN_ID = 'oauth2-token'
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test.describe('OAuth session persistence', () => {
+  test.beforeEach(() => {
+    test.skip(
+      !mocklyAvailable,
+      `Mockly binary not found at bin/${binName} — run: node scripts/download-mockly.mjs`,
+    )
+  })
+
   test.beforeAll(async () => {
     // Start Mockly for the token endpoint.
     mockly = await MocklyServer.create()

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "test": "vitest run",
     "test:integration": "node scripts/download-mockly.mjs && vitest run --config vitest.integration.config.ts",
-    "test:e2e": "playwright test",
-    "test:e2e:headed": "playwright test --headed",
-    "test:e2e:ui": "playwright test --ui",
+    "test:e2e": "node scripts/download-mockly.mjs && playwright test",
+    "test:e2e:headed": "node scripts/download-mockly.mjs && playwright test --headed",
+    "test:e2e:ui": "node scripts/download-mockly.mjs && playwright test --ui",
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "preview": "electron-vite preview",

--- a/scripts/download-mockly.mjs
+++ b/scripts/download-mockly.mjs
@@ -12,7 +12,7 @@ import https from 'https'
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, '..')
 const BIN_DIR = join(ROOT, 'bin')
-const MOCKLY_VERSION = 'v0.1.0'
+const MOCKLY_VERSION = 'v0.5.0'
 
 const ARCH_MAP = { 'x64': 'amd64', 'arm64': 'arm64' }
 const PLATFORM_MAP = { 'win32': 'windows', 'darwin': 'darwin', 'linux': 'linux' }

--- a/src/main/services/__tests__/helpers/mockly.ts
+++ b/src/main/services/__tests__/helpers/mockly.ts
@@ -48,6 +48,25 @@ export interface FaultConfig {
   error_rate?: number
 }
 
+export interface CallEntry {
+  id: string
+  timestamp: string
+  protocol: string
+  method: string
+  path: string
+  status: number
+  duration_ms: number
+  headers?: Record<string, string>
+  /** Raw request body string (e.g. URL-encoded form params for token requests). */
+  body?: string
+  matched_id?: string
+}
+
+export interface CallsResponse {
+  count: number
+  calls: CallEntry[]
+}
+
 // ─── Port utility ─────────────────────────────────────────────────────────────
 
 export function getFreePort(): Promise<number> {
@@ -136,6 +155,37 @@ export class MocklyServer {
   /** Clear fault injection. */
   async clearFault(): Promise<void> {
     await fetch(`${this.apiBase}/api/fault`, { method: 'DELETE' })
+  }
+
+  /** Get logged calls for a mock. */
+  async getCalls(mockId: string): Promise<CallsResponse> {
+    const res = await fetch(`${this.apiBase}/api/calls/http/${mockId}`)
+    if (!res.ok) throw new Error(`getCalls failed: ${res.status}`)
+    return res.json() as Promise<CallsResponse>
+  }
+
+  /** Clear logged calls for a specific mock. */
+  async clearCalls(mockId: string): Promise<void> {
+    await fetch(`${this.apiBase}/api/calls/http/${mockId}`, { method: 'DELETE' })
+  }
+
+  /** Clear all logged HTTP calls. */
+  async clearAllCalls(): Promise<void> {
+    await fetch(`${this.apiBase}/api/calls/http`, { method: 'DELETE' })
+  }
+
+  /**
+   * Block until a mock has been called at least `count` times, or until
+   * `timeoutMs` elapses. Resolves with the matching call entries.
+   */
+  async waitForCalls(mockId: string, count: number, timeoutMs = 5000): Promise<CallEntry[]> {
+    const res = await this._post(`/api/calls/http/${mockId}/wait`, {
+      count,
+      timeout: `${Math.ceil(timeoutMs / 1000)}s`,
+    })
+    if (!res.ok) throw new Error(`waitForCalls timed out after ${timeoutMs}ms (mock: ${mockId})`)
+    const data = await res.json() as CallsResponse
+    return data.calls
   }
 
   /**

--- a/src/main/services/__tests__/helpers/mockly.ts
+++ b/src/main/services/__tests__/helpers/mockly.ts
@@ -166,12 +166,14 @@ export class MocklyServer {
 
   /** Clear logged calls for a specific mock. */
   async clearCalls(mockId: string): Promise<void> {
-    await fetch(`${this.apiBase}/api/calls/http/${mockId}`, { method: 'DELETE' })
+    const res = await fetch(`${this.apiBase}/api/calls/http/${mockId}`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`clearCalls failed for ${mockId}: ${res.status}`)
   }
 
   /** Clear all logged HTTP calls. */
   async clearAllCalls(): Promise<void> {
-    await fetch(`${this.apiBase}/api/calls/http`, { method: 'DELETE' })
+    const res = await fetch(`${this.apiBase}/api/calls/http`, { method: 'DELETE' })
+    if (!res.ok) throw new Error(`clearAllCalls failed: ${res.status}`)
   }
 
   /**

--- a/src/main/services/__tests__/oauth.integration.test.ts
+++ b/src/main/services/__tests__/oauth.integration.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Integration tests for OAuth token flows using Mockly as the real HTTP backend.
+ *
+ * These tests exercise the actual HTTP token request path — real network calls to
+ * a Mockly server — and verify that:
+ *
+ *   • clientCredentials sends the correct form params and returns a Token.
+ *   • refreshTokenGrant sends the correct form params and returns a Token.
+ *   • The token endpoint's error body (error_description) is surfaced in the
+ *     thrown Error so callers can display a meaningful message.
+ *   • The authorizeAuthCode flow reuses the same persistent session partition
+ *     (`persist:oauth-<id>`) across calls so the IDP session cookie is
+ *     preserved between auth attempts (no re-login).
+ *
+ * The database layer is mocked — these tests focus purely on HTTP behaviour.
+ *
+ * Prerequisites: run `node scripts/download-mockly.mjs` to download the binary.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { MocklyServer } from './helpers/mockly'
+import type { OAuthConfig, Token } from '../oauth'
+
+// ─── Mock database (not under test here) ─────────────────────────────────────
+
+vi.mock('../../database', () => ({
+  queryOne: vi.fn(),
+  run: vi.fn(),
+  runTransaction: vi.fn(),
+}))
+
+// ─── Mock Electron (authorizeAuthCode uses BrowserWindow / session) ───────────
+//
+// The session mock records every `session.fromPartition(name)` call so we can
+// assert that the correct persistent partition is used on each auth attempt.
+
+const mockSetCertVerifyProc = vi.hoisted(() => vi.fn())
+const partitionHistory: string[] = []
+
+const mockFromPartition = vi.hoisted(() =>
+  vi.fn().mockImplementation((name: string) => {
+    partitionHistory.push(name)
+    return { setCertificateVerifyProc: mockSetCertVerifyProc }
+  }),
+)
+
+vi.mock('electron', () => {
+  const BrowserWindowMock = vi.fn().mockImplementation(function () {
+    const wcListeners: Record<
+      string,
+      Array<(event: { preventDefault: () => void }, url: string) => void>
+    > = {}
+    const winListeners: Record<string, Array<() => void>> = {}
+
+    const removeListener = <T>(listeners: Record<string, Array<T>>, event: string, handler: T) => {
+      const list = listeners[event]
+      if (!list) return
+      const idx = list.indexOf(handler)
+      if (idx !== -1) list.splice(idx, 1)
+    }
+
+    return {
+      loadURL: vi.fn().mockImplementation((url: string) => {
+        const authUrl = new URL(url)
+        const redirectUri = authUrl.searchParams.get('redirect_uri')
+        const state = authUrl.searchParams.get('state')
+        if (!redirectUri) return
+        const callback = new URL(redirectUri)
+        callback.searchParams.set('code', 'integration-auth-code')
+        if (state) callback.searchParams.set('state', state)
+        setTimeout(() => {
+          const evt = { preventDefault: vi.fn() }
+          wcListeners['will-redirect']?.forEach((fn) => fn(evt, callback.toString()))
+        }, 30)
+      }),
+      webContents: {
+        on: vi.fn().mockImplementation(
+          (
+            event: string,
+            handler: (evt: { preventDefault: () => void }, url: string) => void,
+          ) => {
+            ;(wcListeners[event] ??= []).push(handler)
+          },
+        ),
+        off: vi.fn().mockImplementation(
+          (
+            event: string,
+            handler: (evt: { preventDefault: () => void }, url: string) => void,
+          ) => {
+            removeListener(wcListeners, event, handler)
+          },
+        ),
+      },
+      on: vi.fn().mockImplementation((event: string, handler: () => void) => {
+        ;(winListeners[event] ??= []).push(handler)
+      }),
+      off: vi.fn().mockImplementation((event: string, handler: () => void) => {
+        removeListener(winListeners, event, handler)
+      }),
+      isDestroyed: vi.fn().mockReturnValue(false),
+      close: vi.fn(),
+    }
+  })
+
+  return {
+    BrowserWindow: BrowserWindowMock,
+    session: { fromPartition: mockFromPartition },
+  }
+})
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function parseFormBody(body: string): Record<string, string> {
+  return Object.fromEntries(new URLSearchParams(body))
+}
+
+const TOKEN_MOCK_ID = 'oauth-token'
+
+const TOKEN_RESPONSE = {
+  access_token: 'integration-access-token',
+  token_type: 'Bearer',
+  expires_in: 3600,
+  refresh_token: 'integration-refresh-token',
+  scope: 'read write',
+}
+
+// ─── Shared server setup ─────────────────────────────────────────────────────
+
+let server: MocklyServer
+
+beforeAll(async () => {
+  server = await MocklyServer.create()
+  await server.addMock({
+    id: TOKEN_MOCK_ID,
+    request: { method: 'POST', path: '/oauth2/token' },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(TOKEN_RESPONSE),
+    },
+  })
+}, 30_000)
+
+afterAll(() => server?.stop())
+
+beforeEach(async () => {
+  await server.clearCalls(TOKEN_MOCK_ID)
+  partitionHistory.length = 0
+  mockSetCertVerifyProc.mockClear()
+})
+
+// ─── clientCredentials ────────────────────────────────────────────────────────
+
+describe('clientCredentials', () => {
+  function makeConfig(overrides: Partial<OAuthConfig> = {}): OAuthConfig {
+    return {
+      id: 'test-config-id',
+      name: 'Test Config',
+      grantType: 'client_credentials',
+      clientId: 'test-client',
+      scopes: 'read write',
+      tokenUrl: `${server.httpBase}/oauth2/token`,
+      redirectUri: 'http://localhost:19999/callback',
+      ...overrides,
+    }
+  }
+
+  it('returns a Token with correct fields from the server response', async () => {
+    const { clientCredentials } = await import('../oauth')
+
+    const token = await clientCredentials(makeConfig())
+
+    expect(token.accessToken).toBe('integration-access-token')
+    expect(token.tokenType).toBe('Bearer')
+    expect(token.refreshToken).toBe('integration-refresh-token')
+    expect(token.scope).toBe('read write')
+    expect(token.expiresAt).toBeGreaterThan(Date.now())
+    expect(typeof token.id).toBe('string')
+  })
+
+  it('sends grant_type, client_id, and scope in the POST body', async () => {
+    const { clientCredentials } = await import('../oauth')
+
+    await clientCredentials(makeConfig())
+
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    expect(calls).toHaveLength(1)
+
+    const params = parseFormBody(calls[0].body ?? '')
+    expect(params['grant_type']).toBe('client_credentials')
+    expect(params['client_id']).toBe('test-client')
+    expect(params['scope']).toBe('read write')
+    expect(params['client_secret']).toBeUndefined()
+  })
+
+  it('includes client_secret in the POST body when provided', async () => {
+    const { clientCredentials } = await import('../oauth')
+
+    await clientCredentials(makeConfig({ clientSecret: 's3cr3t' }))
+
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    const params = parseFormBody(calls[0].body ?? '')
+    expect(params['client_secret']).toBe('s3cr3t')
+  })
+
+  it('surfaces the provider error_description when the token endpoint returns 4xx', async () => {
+    const { clientCredentials } = await import('../oauth')
+
+    await server.addMock({
+      id: 'token-error',
+      request: { method: 'POST', path: '/oauth2/token-error' },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          error: 'invalid_client',
+          error_description: 'Client authentication failed',
+        }),
+      },
+    })
+
+    await expect(
+      clientCredentials(makeConfig({ tokenUrl: `${server.httpBase}/oauth2/token-error` })),
+    ).rejects.toThrow('Client authentication failed')
+
+    await server.deleteMock('token-error')
+  })
+
+  it('surfaces the HTTP status when the token endpoint returns 5xx', async () => {
+    const { clientCredentials } = await import('../oauth')
+
+    await server.addMock({
+      id: 'token-500',
+      request: { method: 'POST', path: '/oauth2/token-500' },
+      response: {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ error: 'server_error' }),
+      },
+    })
+
+    await expect(
+      clientCredentials(makeConfig({ tokenUrl: `${server.httpBase}/oauth2/token-500` })),
+    ).rejects.toThrow('500')
+
+    await server.deleteMock('token-500')
+  })
+})
+
+// ─── refreshTokenGrant ────────────────────────────────────────────────────────
+
+describe('refreshTokenGrant', () => {
+  const config: OAuthConfig = {
+    id: 'refresh-config',
+    name: 'Refresh Config',
+    grantType: 'authorization_code',
+    clientId: 'refresh-client',
+    clientSecret: 'refresh-secret',
+    scopes: 'read',
+    tokenUrl: '',
+    redirectUri: 'http://localhost:19999/callback',
+  }
+
+  const existingToken: Token = {
+    id: 'old-token-id',
+    oauthConfigId: 'refresh-config',
+    accessToken: 'old-access-token',
+    refreshToken: 'my-refresh-token',
+    tokenType: 'Bearer',
+    createdAt: Date.now() - 3600_000,
+  }
+
+  it('sends grant_type=refresh_token, refresh_token, client_id, and client_secret', async () => {
+    const { refreshTokenGrant } = await import('../oauth')
+
+    await refreshTokenGrant(existingToken, {
+      ...config,
+      tokenUrl: `${server.httpBase}/oauth2/token`,
+    })
+
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    expect(calls).toHaveLength(1)
+
+    const params = parseFormBody(calls[0].body ?? '')
+    expect(params['grant_type']).toBe('refresh_token')
+    expect(params['refresh_token']).toBe('my-refresh-token')
+    expect(params['client_id']).toBe('refresh-client')
+    expect(params['client_secret']).toBe('refresh-secret')
+  })
+
+  it('returns a new Token with the server response', async () => {
+    const { refreshTokenGrant } = await import('../oauth')
+
+    const token = await refreshTokenGrant(existingToken, {
+      ...config,
+      tokenUrl: `${server.httpBase}/oauth2/token`,
+    })
+
+    expect(token.accessToken).toBe('integration-access-token')
+    expect(token.refreshToken).toBe('integration-refresh-token')
+  })
+
+  it('throws if the token has no refreshToken field', async () => {
+    const { refreshTokenGrant } = await import('../oauth')
+
+    const noRefresh: Token = { ...existingToken, refreshToken: undefined }
+
+    await expect(
+      refreshTokenGrant(noRefresh, {
+        ...config,
+        tokenUrl: `${server.httpBase}/oauth2/token`,
+      }),
+    ).rejects.toThrow('missing refresh token')
+  })
+})
+
+// ─── authorizeAuthCode — session persistence ──────────────────────────────────
+//
+// These tests verify the key session-persistence contract: every call to
+// authorizeAuthCode for the same config uses the *same* persistent Electron
+// session partition (`persist:oauth-<configId>`), which keeps the IDP session
+// cookie alive so the user is not re-prompted to log in.
+
+describe('authorizeAuthCode — session partition persistence', () => {
+  const AUTH_CONFIG: OAuthConfig = {
+    id: 'session-test-config',
+    name: 'Session Test',
+    grantType: 'authorization_code',
+    clientId: 'session-client',
+    scopes: 'openid',
+    authUrl: 'http://127.0.0.1:1/authorize', // irrelevant — BrowserWindow is mocked
+    tokenUrl: ``,
+    redirectUri: 'http://localhost:19999/callback',
+  }
+
+  beforeEach(() => {
+    AUTH_CONFIG.tokenUrl = `${server.httpBase}/oauth2/token`
+  })
+
+  it('uses a persistent partition (persist: prefix) so the session survives', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    await authorizeAuthCode(AUTH_CONFIG)
+
+    // At least one fromPartition call must have used the persist: prefix.
+    expect(partitionHistory.some((p) => p.startsWith('persist:'))).toBe(true)
+  })
+
+  it('derives the partition name from the config id', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    await authorizeAuthCode(AUTH_CONFIG)
+
+    expect(partitionHistory).toContain(`persist:oauth-${AUTH_CONFIG.id}`)
+  })
+
+  it('reuses the same partition across multiple auth attempts for the same config', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    await authorizeAuthCode(AUTH_CONFIG)
+    await authorizeAuthCode(AUTH_CONFIG)
+
+    const relevant = partitionHistory.filter(
+      (p) => p === `persist:oauth-${AUTH_CONFIG.id}`,
+    )
+    // Each call should have used the same named partition (at least twice).
+    expect(relevant.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('uses a different partition when SSL verification is disabled', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    await authorizeAuthCode(AUTH_CONFIG, false)
+
+    expect(partitionHistory).toContain(`persist:oauth-ssl-disabled-${AUTH_CONFIG.id}`)
+    // Must NOT mix the ssl-disabled partition with the normal one.
+    expect(partitionHistory).not.toContain(`persist:oauth-${AUTH_CONFIG.id}`)
+  })
+
+  it('SSL-disabled partition calls setCertificateVerifyProc to bypass validation', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    await authorizeAuthCode(AUTH_CONFIG, false)
+
+    expect(mockSetCertVerifyProc).toHaveBeenCalledOnce()
+  })
+
+  it('different configs get isolated partitions', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const configA = { ...AUTH_CONFIG, id: 'config-a' }
+    const configB = { ...AUTH_CONFIG, id: 'config-b' }
+
+    await authorizeAuthCode(configA)
+    await authorizeAuthCode(configB)
+
+    expect(partitionHistory).toContain('persist:oauth-config-a')
+    expect(partitionHistory).toContain('persist:oauth-config-b')
+  })
+
+  it('token exchange is sent to the token endpoint after the auth redirect', async () => {
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode(AUTH_CONFIG)
+
+    // Verify Mockly received the code exchange request.
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    expect(calls).toHaveLength(1)
+
+    const params = parseFormBody(calls[0].body ?? '')
+    expect(params['grant_type']).toBe('authorization_code')
+    expect(params['code']).toBe('integration-auth-code')
+    expect(params['client_id']).toBe('session-client')
+    expect(params['redirect_uri']).toBe('http://localhost:19999/callback')
+    expect(params['code_verifier']).toBeDefined()
+
+    expect(token.accessToken).toBe('integration-access-token')
+  })
+})

--- a/src/main/services/__tests__/oauth.test.ts
+++ b/src/main/services/__tests__/oauth.test.ts
@@ -549,10 +549,10 @@ describe('OAuth integration', () => {
         expect(idp.requests()).toHaveLength(1)
       })
 
-      it('creates a dedicated session partition and bypasses cert verification when sslVerification is false', async () => {
+      it('creates a persistent partition namespaced to the config and bypasses cert verification when sslVerification is false', async () => {
         await authorizeAuthCode(makeConfig({ tokenUrl: idp.tokenUrl }), false)
 
-        expect(mockFromPartition).toHaveBeenCalledWith(expect.stringMatching(/^oauth-ssl-disabled-/))
+        expect(mockFromPartition).toHaveBeenCalledWith('persist:oauth-ssl-disabled-test-config')
         // The cert verify proc must be called with a callback — pass 0 = OK
         expect(mockSetCertVerifyProc).toHaveBeenCalledWith(expect.any(Function))
         const proc = mockSetCertVerifyProc.mock.calls[0][0] as (req: unknown, cb: (result: number) => void) => void
@@ -561,12 +561,13 @@ describe('OAuth integration', () => {
         expect(callback).toHaveBeenCalledWith(0)
       })
 
-      it('does not touch the session when sslVerification is true (default)', async () => {
+      it('uses a persistent partition keyed to the config id when sslVerification is true (default)', async () => {
         // Use HTTP idp so the request actually completes cleanly
         const httpIdp = await startFakeIdp()
         try {
           await authorizeAuthCode(makeConfig({ tokenUrl: httpIdp.tokenUrl, authUrl: httpIdp.authUrl }))
-          expect(mockFromPartition).not.toHaveBeenCalled()
+          expect(mockFromPartition).toHaveBeenCalledWith('persist:oauth-test-config')
+          expect(mockSetCertVerifyProc).not.toHaveBeenCalled()
         } finally {
           httpIdp.stop()
         }

--- a/src/main/services/oauth.ts
+++ b/src/main/services/oauth.ts
@@ -145,12 +145,15 @@ export async function authorizeAuthCode(config: OAuthConfig, sslVerification = t
   authUrl.searchParams.set('code_challenge', challenge)
   authUrl.searchParams.set('code_challenge_method', 'S256')
 
-  // When SSL verification is disabled, use a unique in-memory session partition
-  // so the auth login page loads against self-signed certificates.  Each attempt
-  // gets its own partition so sessions/cookies are never shared across flows.
-  const partition = sslVerification ? undefined : `oauth-ssl-disabled-${crypto.randomUUID()}`
-  if (partition) {
-    const s = session.fromPartition(partition)
+  // Use a persistent named partition per config so the IDP session (cookies) is
+  // preserved between auth attempts — the user won't be prompted to log in again
+  // as long as their IDP session is still valid.
+  // SSL-disabled configs use a separate namespace so cert policy stays isolated.
+  const partitionName = sslVerification
+    ? `persist:oauth-${config.id}`
+    : `persist:oauth-ssl-disabled-${config.id}`
+  const s = session.fromPartition(partitionName)
+  if (!sslVerification) {
     s.setCertificateVerifyProc((_req, callback) => callback(0))
   }
 
@@ -158,7 +161,7 @@ export async function authorizeAuthCode(config: OAuthConfig, sslVerification = t
     width: 800,
     height: 600,
     autoHideMenuBar: true,
-    webPreferences: { nodeIntegration: false, contextIsolation: true, partition }
+    webPreferences: { nodeIntegration: false, contextIsolation: true, partition: partitionName }
   })
   // Register listener BEFORE loadURL so the redirect is caught even if
   // Keycloak completes it instantly (e.g. an existing session).


### PR DESCRIPTION
## Summary
<!-- One-line description of the change -->

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation / chore

## Changes
<!-- What was changed and why -->

## Testing
<!-- How was this tested? -->

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` completes without errors
