### PR TITLE
#57 Cannot use backstage which are using self signed certificate

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,0 @@
-FROM ghcr.io/dever-labs/devcontainers/frontend-dev:latest
-
-# The base image runs `minikube status || minikube start --driver=docker` as a
-# postStartCommand. Postly doesn't use Kubernetes, and the amd64 minikube binary
-# fails on ARM hosts. Replace it with a no-op stub so the lifecycle hook exits cleanly.
-RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/minikube && chmod +x /usr/local/bin/minikube
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,13 @@
 {
   // Postly dev environment — uses the shared dever-labs frontend-dev image.
-  // The image includes: Node.js LTS, Git, GitHub CLI, Claude Code.
-  // The Dockerfile strips the base image's minikube postStartCommand (not needed for Postly).
-  // Rebuild the container after changes: Dev Containers: Rebuild Container.
   "name": "postly",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  "image": "ghcr.io/dever-labs/devcontainers/frontend-dev:v1.2.1",
 
-  // Install project dependencies on first container creation.
-  "postCreateCommand": "npm install",
+  "postCreateCommand": "bash .devcontainer/init.sh",
 
   "mounts": [
     "source=dever-labs-gh-config,target=/home/vscode/.config/gh,type=volume",
-    "source=dever-labs-copilot-config,target=/home/vscode/.copilot,type=volume"
+    "source=dever-labs-copilot,target=/home/vscode/.copilot,type=volume"
   ],
 
   "remoteEnv": {

--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Installing Copilot CLI and Claude Code..."
+npm install -g @github/copilot @anthropic-ai/claude-code
+sudo ln -sf "$(npm prefix -g)/bin/copilot" /usr/local/bin/copilot
+sudo ln -sf "$(npm prefix -g)/bin/claude" /usr/local/bin/claude
+
+echo "==> Installing npm dependencies..."
+npm install
+
+if ls ~/.copilot/*.json &>/dev/null 2>&1; then
+  echo "✔ GitHub Copilot CLI authenticated."
+else
+  echo "Run 'copilot auth login' to authenticate GitHub Copilot CLI."
+fi

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,6 +78,7 @@ When generating a commit message automatically, you **must**:
 2. **Move detail to the body, never the subject.** Phrases like "to verify X", "in order to Y", "by doing Z", "which ensures W" belong in the body, not the subject line.
 3. **Stop at the object, not the purpose.** `test(oauth): add session persistence tests` is correct. `test(oauth): add session persistence tests to verify token refresh behavior` is too long and wrong.
 4. **Prefer omitting the scope over truncating mid-word.** If `type(scope): description` is too long, try dropping the scope before shortening the description.
+5. **Never list multiple changes with "and" in the subject.** If a commit touches several things, describe only the primary change in the subject and list the rest in the body.
 
 Quick mental check before finalising: `type(scope): description` — count the characters. If > 72, cut.
 
@@ -102,6 +103,7 @@ WIP: experimenting                                  # WIP not allowed
 FEAT: add thing                                     # type must be lowercase
 test(e2e): add OAuth session persistence tests to verify token refresh behavior  # > 72 chars
 feat(oauth): add integration tests to ensure browser session is preserved        # > 72 chars
+chore(devcontainer): remove Dockerfile and add init script for environment setup  # > 72 chars, "and" chains two actions, purpose clause at end
 ```
 
 ---

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -61,6 +61,8 @@ function runMigrations(): void {
   try { db.run("ALTER TABLE requests ADD COLUMN protocol_config TEXT NOT NULL DEFAULT '{}'") } catch {}
   // Collections collapsed state
   try { db.run('ALTER TABLE collections ADD COLUMN collapsed INTEGER NOT NULL DEFAULT 0') } catch {}
+  // Integrations ssl verification
+  try { db.run("ALTER TABLE integrations ADD COLUMN ssl_verification TEXT NOT NULL DEFAULT 'enabled'") } catch {}
   // Draft cache tables (Issue #14) — changes are auto-saved here until explicit save
   db.run(`CREATE TABLE IF NOT EXISTS request_drafts (
     request_id TEXT PRIMARY KEY REFERENCES requests(id) ON DELETE CASCADE,

--- a/src/main/ipc/__tests__/integrations.test.ts
+++ b/src/main/ipc/__tests__/integrations.test.ts
@@ -18,13 +18,21 @@ vi.mock('../../database', () => ({
 }))
 
 vi.mock('../../services/scm-oauth', () => ({}))
+vi.mock('../../services/backstage', () => ({
+  authenticateWithBackstageGuest: vi.fn(),
+  authenticateWithBackstage: vi.fn(),
+  syncCatalog: vi.fn(),
+}))
 vi.mock('../../services/git-local', () => ({ testConnectivity: vi.fn() }))
 
 import { registerIntegrationHandlers } from '../integrations'
 import { queryOne, run } from '../../database'
+import { authenticateWithBackstageGuest, syncCatalog } from '../../services/backstage'
 
 const mockQueryOne = vi.mocked(queryOne)
 const mockRun = vi.mocked(run)
+const mockAuthGuest = vi.mocked(authenticateWithBackstageGuest)
+const mockSyncCatalog = vi.mocked(syncCatalog)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -76,5 +84,83 @@ describe('postly:integrations:create — URL validation', () => {
     }) as { data: unknown; error?: string }
     expect(result.error).toBeUndefined()
     expect(result.data).toBeDefined()
+  })
+})
+
+// ── connect — Backstage SSL verification ─────────────────────────────────────
+
+function makeBackstageIntegration(sslVerification: string) {
+  return {
+    id: 'bs-1',
+    type: 'backstage',
+    base_url: 'https://backstage.example.com',
+    client_id: 'guest',
+    token: '',
+    ssl_verification: sslVerification,
+  }
+}
+
+describe('postly:integrations:connect — Backstage SSL', () => {
+  const guestUser = { name: 'Guest', avatarUrl: '' }
+  const syncResult = { entitiesFound: 2, synced: 2, skipped: 0, errors: [] }
+
+  beforeEach(() => {
+    mockAuthGuest.mockResolvedValue({ token: 'guest-token', user: { name: 'Guest' } })
+    mockSyncCatalog.mockResolvedValue(syncResult)
+  })
+
+  it('passes sslVerification=true to syncCatalog when ssl_verification is "enabled"', async () => {
+    const integration = makeBackstageIntegration('enabled')
+    mockQueryOne.mockReturnValueOnce(integration).mockReturnValueOnce(integration)
+
+    await handlers['postly:integrations:connect'](null, { id: 'bs-1' })
+
+    expect(mockSyncCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ sslVerification: true }),
+    )
+  })
+
+  it('passes sslVerification=false to syncCatalog when ssl_verification is "disabled"', async () => {
+    const integration = makeBackstageIntegration('disabled')
+    mockQueryOne.mockReturnValueOnce(integration).mockReturnValueOnce(integration)
+
+    await handlers['postly:integrations:connect'](null, { id: 'bs-1' })
+
+    expect(mockSyncCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ sslVerification: false }),
+    )
+  })
+
+  it('passes sslVerification=true to authenticateWithBackstageGuest when ssl_verification is "enabled"', async () => {
+    const integration = makeBackstageIntegration('enabled')
+    mockQueryOne.mockReturnValueOnce(integration).mockReturnValueOnce(integration)
+
+    await handlers['postly:integrations:connect'](null, { id: 'bs-1' })
+
+    expect(mockAuthGuest).toHaveBeenCalledWith(
+      'https://backstage.example.com',
+      expect.objectContaining({ sslVerification: true }),
+    )
+  })
+
+  it('passes sslVerification=false to authenticateWithBackstageGuest when ssl_verification is "disabled"', async () => {
+    const integration = makeBackstageIntegration('disabled')
+    mockQueryOne.mockReturnValueOnce(integration).mockReturnValueOnce(integration)
+
+    await handlers['postly:integrations:connect'](null, { id: 'bs-1' })
+
+    expect(mockAuthGuest).toHaveBeenCalledWith(
+      'https://backstage.example.com',
+      expect.objectContaining({ sslVerification: false }),
+    )
+  })
+
+  it('returns an error when the integration is not found', async () => {
+    mockQueryOne.mockReturnValueOnce(null)
+
+    const result = await handlers['postly:integrations:connect'](null, { id: 'missing' }) as { error: string }
+
+    expect(result.error).toBe('Integration not found')
+    expect(mockSyncCatalog).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/__tests__/integrations.test.ts
+++ b/src/main/ipc/__tests__/integrations.test.ts
@@ -101,7 +101,6 @@ function makeBackstageIntegration(sslVerification: string) {
 }
 
 describe('postly:integrations:connect — Backstage SSL', () => {
-  const guestUser = { name: 'Guest', avatarUrl: '' }
   const syncResult = { entitiesFound: 2, synced: 2, skipped: 0, errors: [] }
 
   beforeEach(() => {

--- a/src/main/ipc/backstage.ts
+++ b/src/main/ipc/backstage.ts
@@ -20,11 +20,12 @@ export function registerBackstageHandlers(): void {
         return { error: `Unsupported auth provider: ${JSON.stringify(args.provider)}` }
       }
       const provider = args.provider as OAuthProvider
-      const result = provider === 'guest'
-        ? await authenticateWithBackstageGuest(args.baseUrl)
-        : await authenticateWithBackstage(args.baseUrl, provider)
       const existing = queryOne<{ value: string }>('SELECT value FROM settings WHERE key = ?', ['backstage'])
       const current: BackstageSettings = existing ? JSON.parse(existing.value) : { baseUrl: args.baseUrl, token: '', autoSync: false }
+      const sslVerification = current.sslVerification !== false
+      const result = provider === 'guest'
+        ? await authenticateWithBackstageGuest(args.baseUrl, { sslVerification })
+        : await authenticateWithBackstage(args.baseUrl, provider)
       run(
         'INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)',
         ['backstage', JSON.stringify({ ...current, baseUrl: args.baseUrl, authProvider: provider, token: result.token, connectedUser: result.user })]

--- a/src/main/ipc/integrations.ts
+++ b/src/main/ipc/integrations.ts
@@ -42,7 +42,7 @@ export function registerIntegrationHandlers(): void {
 
   ipcMain.handle('postly:integrations:update', async (_, args: { id: string; [key: string]: unknown }) => {
     try {
-      const allowed = ['name', 'base_url', 'client_id', 'client_secret', 'repo', 'branch', 'token', 'connected_user', 'status', 'error_message']
+      const allowed = ['name', 'base_url', 'client_id', 'client_secret', 'repo', 'branch', 'token', 'connected_user', 'status', 'error_message', 'ssl_verification']
       const fields: string[] = []
       const values: unknown[] = []
       for (const key of allowed) {
@@ -103,9 +103,10 @@ export function registerIntegrationHandlers(): void {
         const raw = (integration.client_id as string) || 'token'
         authProvider = ALLOWED_BS_PROVIDERS.includes(raw as BsProvider) ? raw : 'token'
         const baseUrl = integration.base_url as string
+        const sslVerification = (integration.ssl_verification as string) !== 'disabled'
 
         if (authProvider === 'guest') {
-          const result = await authenticateWithBackstageGuest(baseUrl)
+          const result = await authenticateWithBackstageGuest(baseUrl, { sslVerification })
           token = result.token
           connectedUserJson = JSON.stringify({ name: result.user.name, avatarUrl: result.user.picture ?? '' })
         } else if (authProvider !== 'token') {
@@ -123,8 +124,9 @@ export function registerIntegrationHandlers(): void {
 
       // For Backstage, immediately sync the catalog with the fresh token
       if (type === 'backstage') {
+        const sslVerification = (integration.ssl_verification as string) !== 'disabled'
         try {
-          const syncResult = await syncCatalog({ baseUrl: integration.base_url as string, token, integrationId: args.id, autoSync: false, authProvider: authProvider as BackstageSettings['authProvider'] })
+          const syncResult = await syncCatalog({ baseUrl: integration.base_url as string, token, integrationId: args.id, autoSync: false, authProvider: authProvider as BackstageSettings['authProvider'], sslVerification })
           return { data: queryOne('SELECT * FROM integrations WHERE id = ?', [args.id]), syncResult }
         } catch (syncErr) {
           run('UPDATE integrations SET error_message = ?, updated_at = ? WHERE id = ?',

--- a/src/main/services/__tests__/backstage.test.ts
+++ b/src/main/services/__tests__/backstage.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+vi.mock('../../database', () => ({
+  queryOne: vi.fn(),
+  run: vi.fn(),
+}))
+
+vi.mock('electron', () => ({ BrowserWindow: vi.fn() }))
+
+import axios from 'axios'
+import { syncCatalog, authenticateWithBackstageGuest } from '../backstage'
+
+const mockGet = vi.mocked(axios.get)
+const mockPost = vi.mocked(axios.post)
+
+const EMPTY_CATALOG = { data: [] }
+
+const GUEST_RESPONSE = {
+  data: {
+    backstageIdentity: { token: 'guest-token' },
+    profile: { displayName: 'Guest User', email: 'guest@example.com', picture: 'https://example.com/pic.png' },
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ── syncCatalog — SSL verification ──────────────────────────────────────────
+
+describe('syncCatalog — SSL verification', () => {
+  it('omits httpsAgent when sslVerification is true', async () => {
+    mockGet.mockResolvedValue(EMPTY_CATALOG)
+    await syncCatalog({ baseUrl: 'https://backstage.example.com', token: 'tok', autoSync: false, sslVerification: true })
+    const config = mockGet.mock.calls[0][1] as Record<string, unknown>
+    expect(config.httpsAgent).toBeUndefined()
+  })
+
+  it('omits httpsAgent when sslVerification is omitted (safe default)', async () => {
+    mockGet.mockResolvedValue(EMPTY_CATALOG)
+    await syncCatalog({ baseUrl: 'https://backstage.example.com', token: 'tok', autoSync: false })
+    const config = mockGet.mock.calls[0][1] as Record<string, unknown>
+    expect(config.httpsAgent).toBeUndefined()
+  })
+
+  it('sets httpsAgent on all axios.get calls when sslVerification is false', async () => {
+    mockGet.mockResolvedValue(EMPTY_CATALOG)
+    await syncCatalog({ baseUrl: 'https://backstage.example.com', token: 'tok', autoSync: false, sslVerification: false })
+    // Both parallel calls (APIs + Components) must carry the agent
+    expect(mockGet.mock.calls).toHaveLength(2)
+    for (const call of mockGet.mock.calls) {
+      expect((call[1] as Record<string, unknown>).httpsAgent).toBeDefined()
+    }
+  })
+
+  it('sets Authorization header with token', async () => {
+    mockGet.mockResolvedValue(EMPTY_CATALOG)
+    await syncCatalog({ baseUrl: 'https://backstage.example.com', token: 'my-token', autoSync: false })
+    const config = mockGet.mock.calls[0][1] as { headers: Record<string, string> }
+    expect(config.headers['Authorization']).toBe('Bearer my-token')
+  })
+
+  it('calls the correct catalog endpoints', async () => {
+    mockGet.mockResolvedValue(EMPTY_CATALOG)
+    await syncCatalog({ baseUrl: 'https://backstage.example.com', token: 'tok', autoSync: false })
+    const urls = mockGet.mock.calls.map((c) => c[0] as string)
+    expect(urls).toContain('https://backstage.example.com/api/catalog/entities?filter=kind=API')
+    expect(urls).toContain('https://backstage.example.com/api/catalog/entities?filter=kind=Component')
+  })
+
+  it('throws when baseUrl is empty', async () => {
+    await expect(
+      syncCatalog({ baseUrl: '', token: 'tok', autoSync: false }),
+    ).rejects.toThrow('Backstage base URL is not configured')
+  })
+
+  it('throws when token provider requires a token but none is set', async () => {
+    await expect(
+      syncCatalog({ baseUrl: 'https://backstage.example.com', token: '', autoSync: false, authProvider: 'token' }),
+    ).rejects.toThrow('Backstage token is not configured')
+  })
+
+  it('returns entitiesFound=0 when the catalog is empty', async () => {
+    mockGet.mockResolvedValue(EMPTY_CATALOG)
+    const result = await syncCatalog({ baseUrl: 'https://backstage.example.com', token: 'tok', autoSync: false })
+    expect(result.entitiesFound).toBe(0)
+    expect(result.synced).toBe(0)
+    expect(result.errors).toHaveLength(0)
+  })
+})
+
+// ── authenticateWithBackstageGuest — SSL verification ───────────────────────
+
+describe('authenticateWithBackstageGuest — SSL verification', () => {
+  it('omits httpsAgent when sslVerification is true', async () => {
+    mockPost.mockResolvedValue(GUEST_RESPONSE)
+    await authenticateWithBackstageGuest('https://backstage.example.com', { sslVerification: true })
+    const config = mockPost.mock.calls[0][2] as Record<string, unknown>
+    expect(config.httpsAgent).toBeUndefined()
+  })
+
+  it('omits httpsAgent when options are omitted (safe default)', async () => {
+    mockPost.mockResolvedValue(GUEST_RESPONSE)
+    await authenticateWithBackstageGuest('https://backstage.example.com')
+    const config = mockPost.mock.calls[0][2] as Record<string, unknown>
+    expect(config.httpsAgent).toBeUndefined()
+  })
+
+  it('sets httpsAgent when sslVerification is false', async () => {
+    mockPost.mockResolvedValue(GUEST_RESPONSE)
+    await authenticateWithBackstageGuest('https://backstage.example.com', { sslVerification: false })
+    const config = mockPost.mock.calls[0][2] as Record<string, unknown>
+    expect(config.httpsAgent).toBeDefined()
+  })
+
+  it('calls the guest/refresh endpoint on the correct base URL', async () => {
+    mockPost.mockResolvedValue(GUEST_RESPONSE)
+    await authenticateWithBackstageGuest('https://backstage.example.com/')
+    expect(mockPost.mock.calls[0][0]).toBe('https://backstage.example.com/api/auth/guest/refresh')
+  })
+
+  it('returns token and user from response', async () => {
+    mockPost.mockResolvedValue(GUEST_RESPONSE)
+    const result = await authenticateWithBackstageGuest('https://backstage.example.com')
+    expect(result.token).toBe('guest-token')
+    expect(result.user.name).toBe('Guest User')
+    expect(result.user.email).toBe('guest@example.com')
+    expect(result.user.picture).toBe('https://example.com/pic.png')
+  })
+
+  it('throws when response has no token', async () => {
+    mockPost.mockResolvedValue({ data: { backstageIdentity: {} } })
+    await expect(
+      authenticateWithBackstageGuest('https://backstage.example.com'),
+    ).rejects.toThrow('Guest refresh did not return a token')
+  })
+})

--- a/src/main/services/backstage.ts
+++ b/src/main/services/backstage.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron'
 import axios from 'axios'
+import https from 'https'
 import crypto from 'crypto'
 import yaml from 'js-yaml'
 import { queryOne, run } from '../database'
@@ -12,6 +13,7 @@ export interface BackstageSettings {
   integrationId?: string
   authProvider?: 'token' | 'guest' | 'gitlab' | 'github' | 'google'
   connectedUser?: { name: string; email?: string; picture?: string }
+  sslVerification?: boolean
 }
 
 export interface SyncResult {
@@ -72,10 +74,15 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
   const headers: Record<string, string> = {}
   if (settings.token) headers['Authorization'] = `Bearer ${settings.token}`
 
+  // codeql[js/disabling-certificate-validation] -- intentional: user-controlled dev setting
+  const httpsAgent = settings.sslVerification === false
+    ? new https.Agent({ rejectUnauthorized: false })
+    : undefined
+
   // Fetch all API + Component entities in parallel
   const [apisRes, compsRes] = await Promise.all([
-    axios.get<BackstageApiEntity[]>(`${settings.baseUrl}/api/catalog/entities?filter=kind=API`, { headers }),
-    axios.get<BackstageComponentEntity[]>(`${settings.baseUrl}/api/catalog/entities?filter=kind=Component`, { headers }),
+    axios.get<BackstageApiEntity[]>(`${settings.baseUrl}/api/catalog/entities?filter=kind=API`, { headers, httpsAgent }),
+    axios.get<BackstageComponentEntity[]>(`${settings.baseUrl}/api/catalog/entities?filter=kind=Component`, { headers, httpsAgent }),
   ])
 
   const allApis = Array.isArray(apisRes.data) ? apisRes.data : []
@@ -157,7 +164,7 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
           if (!spec) {
             const specUrl = api.metadata.annotations?.['backstage.io/api-spec']
             if (specUrl) {
-              try { spec = (await axios.get(specUrl, { headers })).data }
+              try { spec = (await axios.get(specUrl, { headers, httpsAgent })).data }
               catch (err) { result.errors.push(`${col.label}/${apiName}: failed to fetch spec — ${String(err)}`); continue }
             }
           }
@@ -221,12 +228,17 @@ const AUTH_TIMEOUT_MS = 5 * 60 * 1000
  */
 export async function authenticateWithBackstageGuest(
   baseUrl: string,
+  options: { sslVerification?: boolean } = {},
 ): Promise<{ token: string; user: { name: string; email?: string; picture?: string } }> {
   const base = baseUrl.replace(/\/$/, '')
+  // codeql[js/disabling-certificate-validation] -- intentional: user-controlled dev setting
+  const httpsAgent = options.sslVerification === false
+    ? new https.Agent({ rejectUnauthorized: false })
+    : undefined
   const resp = await axios.post<{
     backstageIdentity?: { token?: string }
     profile?: { displayName?: string; email?: string; picture?: string }
-  }>(`${base}/api/auth/guest/refresh`, {}, { headers: { 'Content-Type': 'application/json' } })
+  }>(`${base}/api/auth/guest/refresh`, {}, { headers: { 'Content-Type': 'application/json' }, httpsAgent })
 
   const token = resp.data?.backstageIdentity?.token
   if (!token) throw new Error('Guest refresh did not return a token')

--- a/src/renderer/src/components/integrations/IntegrationEditPage.tsx
+++ b/src/renderer/src/components/integrations/IntegrationEditPage.tsx
@@ -76,6 +76,7 @@ export function IntegrationEditPage({ integrationId }: { integrationId: string }
   const [baseUrl, setBaseUrl] = useState(integration?.baseUrl ?? DEFAULTS[integration?.type ?? 'git']?.baseUrl ?? '')
   const [clientId, setClientId] = useState(integration?.clientId ?? '')
   const [token, setToken] = useState(integration?.token ?? '')
+  const [sslVerification, setSslVerification] = useState(integration?.sslVerification !== false)
 
   const [reconnecting, setReconnecting] = useState(false)
   const [connectedUser, setConnectedUser] = useState<Integration['connectedUser']>(integration?.connectedUser ?? null)
@@ -105,6 +106,9 @@ export function IntegrationEditPage({ integrationId }: { integrationId: string }
     if (token && (type === 'backstage')) {
       await window.api.integrations.update({ id: integrationId, token })
     }
+    if (type === 'backstage') {
+      await window.api.integrations.update({ id: integrationId, ssl_verification: sslVerification ? 'enabled' : 'disabled' })
+    }
     await loadIntegrations()
     addToast('Saved', 'success')
     clearSelectedItem()
@@ -132,6 +136,7 @@ export function IntegrationEditPage({ integrationId }: { integrationId: string }
         await loadIntegrations(); await loadCollections()
       } else if (type === 'backstage') {
         if (token) await window.api.integrations.update({ id: integrationId, token })
+        await window.api.integrations.update({ id: integrationId, ssl_verification: sslVerification ? 'enabled' : 'disabled' })
         const { data, error: connErr, syncError, syncResult } = await window.api.integrations.connect({ id: integrationId }) as {
           data: unknown; error?: string; syncError?: string
           syncResult?: { entitiesFound: number; synced: number; skipped: number; errors: string[] }
@@ -244,6 +249,15 @@ export function IntegrationEditPage({ integrationId }: { integrationId: string }
                   {connectedUser && (
                     <p className="text-xs text-th-text-subtle">Connected as <span className="text-th-text-secondary">{connectedUser.name}</span></p>
                   )}
+                  <label className="flex cursor-pointer items-center gap-3">
+                    <input
+                      type="checkbox"
+                      checked={!sslVerification}
+                      onChange={(e) => setSslVerification(!e.target.checked)}
+                      className="h-4 w-4 accent-blue-500"
+                    />
+                    <span className="text-sm text-th-text-secondary">Skip SSL verification</span>
+                  </label>
                 </>
               )}
 

--- a/src/renderer/src/components/integrations/IntegrationSetupPage.tsx
+++ b/src/renderer/src/components/integrations/IntegrationSetupPage.tsx
@@ -81,6 +81,7 @@ export function IntegrationSetupPage() {
   const [bsName, setBsName] = useState('Backstage')
   const [bsToken, setBsToken] = useState('')
   const [bsProvider, setBsProvider] = useState<'token' | 'guest' | 'gitlab' | 'github' | 'google'>('guest')
+  const [bsSslVerification, setBsSslVerification] = useState(true)
 
   const [error, setError] = useState<string | null>(null)
 
@@ -147,6 +148,7 @@ export function IntegrationSetupPage() {
         if (createErr) { setError(createErr); setConnecting(false); return }
         const id = (createData as Record<string, unknown>).id as string
         if (bsProvider === 'token' && bsToken) await api.integrations.update({ id, token: bsToken })
+        await api.integrations.update({ id, ssl_verification: bsSslVerification ? 'enabled' : 'disabled' })
         const { error: connErr } = await api.integrations.connect({ id })
         if (connErr) { setError(connErr); setConnecting(false); return }
         setConnectedUser({ name: 'Backstage', avatarUrl: '' })
@@ -389,6 +391,16 @@ export function IntegrationSetupPage() {
               {bsProvider !== 'token' && bsProvider !== 'guest' && (
                 <p className="text-xs text-th-text-subtle">A browser window will open to sign in via {bsProvider.charAt(0).toUpperCase() + bsProvider.slice(1)}.</p>
               )}
+
+              <label className="flex cursor-pointer items-center gap-3">
+                <input
+                  type="checkbox"
+                  checked={!bsSslVerification}
+                  onChange={(e) => setBsSslVerification(!e.target.checked)}
+                  className="h-4 w-4 accent-blue-500"
+                />
+                <span className="text-sm text-th-text-secondary">Skip SSL verification</span>
+              </label>
 
               {error && <p className="rounded-sm bg-rose-900/30 px-3 py-2 text-xs text-rose-400">{error}</p>}
 

--- a/src/renderer/src/components/settings/tabs/BackstageSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/BackstageSettings.tsx
@@ -163,6 +163,16 @@ export function BackstageSettings() {
           />
           <span className="text-sm text-th-text-secondary">Auto-sync on startup</span>
         </label>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={settings.sslVerification === false}
+            onChange={(e) => setSettings({ ...settings, sslVerification: e.target.checked ? false : true })}
+            className="h-4 w-4 accent-blue-500"
+          />
+          <span className="text-sm text-th-text-secondary">Skip SSL verification</span>
+        </label>
       </div>
 
       <div className="flex gap-2">

--- a/src/renderer/src/store/integrations.ts
+++ b/src/renderer/src/store/integrations.ts
@@ -26,6 +26,7 @@ function normalize(raw: Record<string, unknown>): Integration {
     branch: (raw.branch ?? 'main') as string,
     status: (raw.status ?? 'disconnected') as Integration['status'],
     errorMessage: (raw.error_message ?? raw.errorMessage ?? '') as string,
+    sslVerification: (raw.ssl_verification ?? raw.sslVerification) !== 'disabled',
     createdAt: (raw.created_at ?? raw.createdAt ?? 0) as number,
     updatedAt: (raw.updated_at ?? raw.updatedAt ?? 0) as number,
   }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -54,6 +54,7 @@ export interface Integration {
   branch: string
   status: 'connected' | 'disconnected' | 'error'
   errorMessage?: string
+  sslVerification?: boolean
   createdAt: number
   updatedAt: number
 }
@@ -164,6 +165,7 @@ export interface BackstageSettings {
   autoSync: boolean
   authProvider?: 'token' | 'guest' | 'gitlab' | 'github' | 'google'
   connectedUser?: { name: string; email?: string; picture?: string }
+  sslVerification?: boolean
 }
 
 export interface GitHubSettings {


### PR DESCRIPTION
## Summary
<!-- One-line description of the change -->

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation / chore

## Changes
Add support for being able to enable or disable ssl verifications for source integration

## Testing
Unit tests, integration tests and manual testing

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] `npm run build` completes without errors
