### PR TITLE
feat(updater): auto-update with enterprise disconnected-mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ Configure auth once on a collection or group, and requests inherit it automatica
 | **Inherit** | Walk up to group → collection → integration |
 
 ### Source Integrations
-Pull APIs directly from:
-- **Backstage** — discovers APIs via the Backstage catalog
-- **GitHub** — reads OpenAPI specs from repositories
-- **GitLab** — reads OpenAPI specs from repositories
+Pull APIs directly from any git repository or Backstage:
+- **Any git host** — GitHub, GitLab, Gitea, Azure DevOps, Bitbucket, self-hosted — uses your system git credentials (SSH or HTTPS, no token setup needed in the app)
+- **Backstage** — discovers APIs via the Backstage software catalog
 
-Collections from each source appear as separate groups in the sidebar. Changes can be committed back to source control from within the app.
+Collections from each source appear as separate groups in the sidebar. `*.postly.json` collection files can be committed back to the repository from within the app; OpenAPI specs are read-only.
 
 ### Environments
 - Multiple named environments with key-value variables

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Collections from each source appear as separate groups in the sidebar. Changes c
 - Dark and light theme
 - Breadcrumb navigation (Source › Collection › Group › Request)
 
+### Automatic Updates
+Postly checks for updates automatically on startup and shows a notification banner when a new version is available. Updates are downloaded in the background and applied on the next restart.
+
+Configure update behaviour in **Settings → Updates**:
+- Toggle automatic startup checks on or off
+- Set a custom internal update server URL for enterprise/air-gapped deployments
+
+See [docs/updates.md](docs/updates.md) for enterprise deployment options.
+
 ---
 
 ## Download

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,7 +79,9 @@ postly/
 | `npm run dist:mac` | Package for macOS (x64 + arm64) |
 | `npm run dist:linux` | Package for Linux (x64 + arm64) |
 | `npm test` | Run unit tests with Vitest |
+| `npm run test:integration` | Run integration tests (downloads Mockly binary first) |
 | `npm run test:e2e` | Run Playwright E2E tests (requires `npm run build` first) |
+| `npm run typecheck` | TypeScript type-check without emitting files |
 | `npm run lint` | Lint TypeScript source |
 
 ---

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,57 +1,55 @@
-# Connecting Integrations
+# Connecting Sources
 
-Postly can sync API collections from three external sources: **GitHub**, **GitLab**, and **Backstage**. Each source appears as its own collapsible group in the sidebar alongside your local collections.
+Postly can sync API collections from two types of external sources: **Git repositories** and **Backstage**. Each source appears as its own collapsible group in the sidebar alongside your local collections.
 
----
-
-## GitHub
-
-### Prerequisites
-
-Create a **GitHub OAuth App** (no client secret required — Postly uses the Device Flow standard):
-
-1. Go to **GitHub → Settings → Developer settings → OAuth Apps → New OAuth App**
-2. Set **Homepage URL** to `http://localhost`
-3. Set **Authorization callback URL** to `http://localhost`
-4. Copy the **Client ID** (you do not need the client secret)
-
-### Connecting
-
-1. In Postly, click **Connect a source** at the bottom of the sidebar
-2. Select **GitHub**
-3. Enter a display name and your GitHub base URL (`https://github.com` or your GitHub Enterprise URL)
-4. Paste the **Client ID**
-5. Enter the **repository** to sync from (`owner/repo`)
-6. Enter the default **branch** (e.g. `main`)
-7. Click **Save & Reconnect** — you will be shown a device code to approve at github.com/login/device
-8. Once approved, collections from the repository are imported into the sidebar
-
-### What gets synced
-
-Postly looks for a `postly.json` file (or files matching `*.postly.json`) at the root of the configured repository and branch. The file format is the same as the Postly export format.
+To add a source, click **Add Git Source** at the bottom of the sidebar.
 
 ---
 
-## GitLab
+## Git repository
 
-### Prerequisites
+The **Git** source type works with any git host — GitHub, GitLab, Gitea, Azure DevOps, Bitbucket, or any self-hosted git server. Postly clones the repository locally using your system's git credentials; no token or OAuth setup is required inside the app.
 
-Create a **GitLab OAuth Application**:
+### Authentication
 
-1. Go to **GitLab → User Settings → Applications** (or the Admin Area for instance-wide)
-2. Set **Redirect URI** to `http://localhost`
-3. Enable the `read_api` scope
-4. Copy the **Application ID** (Client ID)
+Postly delegates authentication to your system git tooling:
+
+| URL style | How credentials are resolved |
+|---|---|
+| `https://github.com/org/repo` | Git Credential Manager, macOS Keychain, `~/.netrc`, etc. |
+| `git@github.com:org/repo.git` | SSH agent or `~/.ssh/id_ed25519` / `id_rsa` (auto-detected) |
+| `https://gitlab.example.com/…` | Same as HTTPS above |
+| Any self-hosted | Same rules — whatever your system git would use |
+
+If `git clone <url>` works in your terminal, it will work in Postly.
 
 ### Connecting
 
-1. In Postly, click **Connect a source**
-2. Select **GitLab**
-3. Enter a display name and your GitLab base URL (`https://gitlab.com` or your self-hosted URL)
-4. Paste the **Application ID** as the Client ID
-5. Enter the **repository** (`namespace/project`) and **branch**
-6. Click **Save & Reconnect** — you will be shown a device code to approve on your GitLab instance
-7. Once approved, collections are synced from the repository
+1. Click **Add Git Source** in the sidebar
+2. Select **Git repository**
+3. Paste the repository URL (HTTPS or SSH)
+4. Optionally edit the display name (auto-filled from `org/repo`)
+5. Set the default branch (default: `main`)
+6. Click **Connect** — Postly clones the repository and imports any API definitions it finds
+
+### What gets imported
+
+Postly auto-discovers API definitions on connect and sync:
+
+| File(s) found | What happens |
+|---|---|
+| `openapi.yaml` / `openapi.json` | Imported as a collection with groups per tag |
+| `swagger.yaml` / `swagger.json` | Same |
+| `openapi/openapi.yaml`, `docs/openapi.yaml`, `api/openapi.yaml` | Same |
+| `*.postly.json` | Imported as a full Postly collection (requests, auth, groups) |
+
+Multiple files can coexist — each produces a separate collection in the sidebar.
+
+### Syncing and committing
+
+- Click the **Sync** icon next to a git source to pull the latest changes from the remote branch
+- For `*.postly.json` collections, you can edit requests and commit changes back to the repository using the **Commit** panel (commit icon in the request editor toolbar)
+- Changes to OpenAPI-sourced collections are read-only from Postly's perspective — edit the spec file in your repo
 
 ---
 
@@ -65,23 +63,17 @@ Optionally, create a **service account token** if your Backstage instance requir
 
 ### Connecting
 
-1. In Postly, click **Connect a source**
-2. Select **Backstage**
-3. Enter a display name and your Backstage base URL (e.g. `http://localhost:7007`)
-4. Optionally enter a **service account token** if required
-5. Set the **default path** (defaults to `/api/catalog`)
-6. Click **Save & Connect**
+1. Click **Add Git Source** → select **Backstage**
+2. Enter a display name and your Backstage base URL (e.g. `http://localhost:7007`)
+3. Optionally enter a **service account token** if required
+4. Click **Connect**
 
-Postly will fetch all API entities from the catalog and create a collection group for each one that contains OpenAPI/Swagger definitions.
+Postly fetches all API entities from the catalog and creates a collection for each one that has an OpenAPI/Swagger definition.
 
 ---
 
-## Managing integrations
+## Managing sources
 
 - Click the **settings icon** next to any connected source in the sidebar to edit its configuration
-- To remove a source, open the edit page and scroll down to the **Remove** section
-- Collections synced from a source are read-only by default; to make local changes, drag collections to your **Local** source
-
-## Committing changes
-
-For GitHub and GitLab sources, Postly includes a **Commit panel** that lets you write a commit message and push changes back to the source repository directly from the app. Open it via the commit icon in the request editor toolbar.
+- To remove a source, open the settings page and scroll down to the **Remove** section
+- Collections synced from a git or Backstage source are read-only by default; drag them to **Local** to make fully independent copies

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,110 @@
+# Updates & Enterprise Deployment
+
+## Standard auto-update
+
+Postly uses [electron-updater](https://www.electron.build/auto-update) to check for and apply updates from GitHub Releases. The update lifecycle is:
+
+1. On startup (if **Check for updates on startup** is enabled), Postly checks the release feed
+2. If a newer version is found, a notification banner appears at the top of the window
+3. Click **Download** to fetch the installer in the background (progress is shown)
+4. Click **Install & Restart** once the download completes
+
+You can also trigger a manual check at any time via **Settings → Updates → Check for updates now**.
+
+---
+
+## Enterprise / Disconnected deployment
+
+For environments that cannot reach GitHub directly (corporate proxies, air-gapped networks, or controlled rollout scenarios), Postly supports an **internal update mirror**.
+
+### How it works
+
+Instead of checking GitHub Releases, Postly points to a server you control. That server serves the version manifest and installer files in the standard electron-updater [generic provider](https://www.electron.build/configuration/publish#genericserveroptions) format. Postly's GitHub Releases channel is completely unaffected — the two paths are fully isolated.
+
+```
+Postly (packaged)
+    │
+    ├─ [no enterprise config]  →  GitHub Releases (dever-labs/postly)
+    │
+    └─ [enterprise config set] →  Your internal server
+                                       ├── latest-mac.yml
+                                       ├── latest.yml          (Windows)
+                                       ├── latest-linux.yml
+                                       ├── Postly-x.x.x.dmg
+                                       ├── Postly-Setup-x.x.x.exe
+                                       └── Postly-x.x.x.AppImage
+```
+
+### Setting up the internal mirror
+
+1. **Download** the release assets from [github.com/dever-labs/postly/releases](https://github.com/dever-labs/postly/releases) for the version you want to deploy.
+
+2. **Host** the files on any HTTP/HTTPS server (nginx, S3-compatible, IIS, etc.) under a single base URL, e.g. `https://updates.internal.corp/postly/`.
+
+3. The directory must contain the platform manifest files (`latest-mac.yml`, `latest.yml`, `latest-linux.yml`) alongside the installer binaries. These files are included in every GitHub release.
+
+**Example `latest-mac.yml`:**
+```yaml
+version: 1.2.0
+files:
+  - url: Postly-1.2.0-arm64.dmg
+    sha512: <hash from release>
+    size: 94371840
+  - url: Postly-1.2.0.dmg
+    sha512: <hash from release>
+    size: 97123456
+path: Postly-1.2.0-arm64.dmg
+sha512: <hash from release>
+releaseDate: '2025-05-30T00:00:00.000Z'
+```
+
+> Tip: simply mirror the exact files from the GitHub release — the YAML manifests are already in the correct format and do not need editing.
+
+### Configuring Postly to use your mirror
+
+#### Option A — Bundled enterprise config (recommended for IT deployment)
+
+Place an `enterprise.json` file in the `resources/` directory of the packaged application **before distributing it**. This requires repackaging after download, but means users need zero configuration.
+
+File location inside the app bundle:
+
+| Platform | Path |
+|---|---|
+| macOS | `Postly.app/Contents/Resources/enterprise.json` |
+| Windows | `resources/enterprise.json` (next to the executable) |
+| Linux | `resources/enterprise.json` |
+
+**`enterprise.json` format:**
+```json
+{
+  "updateUrl": "https://updates.internal.corp/postly/"
+}
+```
+
+When this file is present, Postly shows **"Managed by your administrator"** in the Updates settings and the URL field is locked — users cannot override it.
+
+#### Option B — Per-user setting
+
+In **Settings → Updates → Enterprise / Disconnected Mode**, enter the internal server URL. Postly will use this URL for all future update checks. Clearing the field reverts to the GitHub Releases channel.
+
+This option is suitable for individual users on networks that block GitHub but have access to an internal mirror.
+
+---
+
+## Rollback and version control
+
+Because your internal server controls the `latest-mac.yml` / `latest.yml` manifest, you have full control over which version Postly considers "latest":
+
+- **Deploy a new version:** update the manifest to point to the new installer
+- **Roll back to a previous version:** update the manifest to point to the older installer — Postly will offer an "update" to the older version
+- **Staged rollout:** serve different manifests to different user groups by routing to different paths
+
+There is no rollback mechanism through the standard GitHub Releases channel.
+
+---
+
+## Security considerations
+
+- electron-updater verifies the **SHA-512 hash** of every downloaded file against the value in the manifest before applying the update. Tampered installers will be rejected.
+- Use **HTTPS** for your internal mirror to prevent man-in-the-middle attacks on the manifest or binaries.
+- The bundled `enterprise.json` approach prevents users from accidentally pointing Postly at an unintended update source.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "electron-store": "^11.0.2",
+        "electron-updater": "^6.8.3",
         "httpntlm": "^1.8.13",
         "lucide-react": "^1.16.0",
         "monaco-editor": "^0.55.1",
@@ -5537,7 +5538,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -6519,6 +6519,22 @@
       "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
     },
     "node_modules/electron-vite": {
       "version": "5.0.0",
@@ -7560,7 +7576,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -7842,7 +7857,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/happy-dom": {
@@ -8798,7 +8812,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -8837,7 +8850,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -9142,6 +9154,19 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/long": {
@@ -10691,7 +10716,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -11394,6 +11418,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11689,7 +11719,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "openapi-types": "^12.1.3",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "rolldown": "^1.0.3",
         "simple-git": "^3.36.0",
         "sql.js": "^1.14.1",
         "tailwind-merge": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "openapi-types": "^12.1.3",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
+        "rolldown": "^1.0.3",
         "simple-git": "^3.36.0",
         "sql.js": "^1.14.1",
         "tailwind-merge": "^3.6.0",
@@ -78,6 +79,9 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.14",
         "vitest": "^4.1.7"
+      },
+      "optionalDependencies": {
+        "rolldown": "^1.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -788,7 +792,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -800,7 +803,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -811,7 +813,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1610,6 +1611,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1627,6 +1631,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1644,6 +1651,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1661,6 +1671,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1678,6 +1691,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1695,6 +1711,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1712,6 +1731,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1729,6 +1751,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1746,6 +1771,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1769,6 +1797,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1792,6 +1823,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1815,6 +1849,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1838,6 +1875,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1861,6 +1901,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1884,6 +1927,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1907,6 +1953,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2172,7 +2221,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2201,11 +2249,11 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
-      "dev": true,
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -3295,13 +3343,12 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3312,13 +3359,12 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3329,13 +3375,12 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3346,13 +3391,12 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3363,13 +3407,12 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3380,13 +3423,15 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3397,13 +3442,15 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3414,13 +3461,15 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3431,13 +3480,15 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3448,13 +3499,15 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3465,13 +3518,15 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3482,13 +3537,12 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3499,13 +3553,12 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3518,13 +3571,12 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3535,13 +3587,12 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3555,7 +3606,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@simple-git/args-pathspec": {
@@ -3739,6 +3790,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3756,6 +3810,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3773,6 +3830,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3790,6 +3850,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3828,72 +3891,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.0",
@@ -4024,7 +4021,6 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9009,6 +9005,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9030,6 +9029,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9051,6 +9053,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9072,6 +9077,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -10587,13 +10595,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
-      "dev": true,
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -10603,21 +10611,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/safe-array-concat": {
@@ -11915,6 +11923,291 @@
         }
       }
     },
+    "node_modules/vite/node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/vite/node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/vite/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -11926,6 +12219,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron-store": "^11.0.2",
+    "electron-updater": "^6.8.3",
     "httpntlm": "^1.8.13",
     "lucide-react": "^1.16.0",
     "monaco-editor": "^0.55.1",

--- a/package.json
+++ b/package.json
@@ -217,5 +217,8 @@
     "tailwind-merge": "^3.6.0",
     "ws": "^8.21.0",
     "zustand": "^5.0.13"
+  },
+  "optionalDependencies": {
+    "rolldown": "^1.0.3"
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,8 +52,9 @@ app.whenReady().then(async () => {
   const win = createWindow()
   attachWindowEvents(win)
 
+  // Always init so dev-mode "check now" button can emit events back to renderer
+  initUpdater(win)
   if (app.isPackaged) {
-    initUpdater(win)
     const generalSettings = getGeneralSettings()
     if (generalSettings.autoUpdate) {
       if (generalSettings.updateFeedUrl) setUpdateFeedUrl(generalSettings.updateFeedUrl)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,6 +3,8 @@ import { join } from 'path'
 import { platform } from 'process'
 import { initDatabase } from './database'
 import { registerAllIpcHandlers, attachWindowEvents } from './ipc'
+import { initUpdater, checkForUpdates, setUpdateFeedUrl } from './services/updater'
+import { getGeneralSettings } from './ipc/settings-utils'
 
 function createWindow(): BrowserWindow {
   // Use ICO on Windows for proper multi-resolution title bar / taskbar icon
@@ -49,6 +51,15 @@ app.whenReady().then(async () => {
   registerAllIpcHandlers()
   const win = createWindow()
   attachWindowEvents(win)
+
+  if (app.isPackaged) {
+    initUpdater(win)
+    const generalSettings = getGeneralSettings()
+    if (generalSettings.autoUpdate) {
+      if (generalSettings.updateFeedUrl) setUpdateFeedUrl(generalSettings.updateFeedUrl)
+      checkForUpdates()
+    }
+  }
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       const w = createWindow()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { platform } from 'process'
 import { initDatabase } from './database'
 import { registerAllIpcHandlers, attachWindowEvents } from './ipc'
-import { initUpdater, checkForUpdates, setUpdateFeedUrl } from './services/updater'
+import { initUpdater, checkForUpdates, applyFeedUrl, getEnterpriseConfig } from './services/updater'
 import { getGeneralSettings } from './ipc/settings-utils'
 
 function createWindow(): BrowserWindow {
@@ -57,7 +57,11 @@ app.whenReady().then(async () => {
   if (app.isPackaged) {
     const generalSettings = getGeneralSettings()
     if (generalSettings.autoUpdate) {
-      if (generalSettings.updateFeedUrl) setUpdateFeedUrl(generalSettings.updateFeedUrl)
+      // Enterprise bundled config takes precedence over user setting.
+      // Neither affects the default GitHub Releases channel used by normal builds.
+      const enterprise = getEnterpriseConfig()
+      const effectiveUrl = enterprise.updateUrl ?? generalSettings.updateFeedUrl
+      applyFeedUrl(effectiveUrl)
       checkForUpdates()
     }
   }

--- a/src/main/ipc/__tests__/oauth.test.ts
+++ b/src/main/ipc/__tests__/oauth.test.ts
@@ -27,7 +27,7 @@ vi.mock('../../services/oauth', () => ({
 }))
 
 vi.mock('../settings-utils', () => ({
-  getGeneralSettings: vi.fn().mockReturnValue({ sslVerification: true, followRedirects: true, defaultTimeout: 30000 }),
+  getGeneralSettings: vi.fn().mockReturnValue({ sslVerification: true, followRedirects: true, defaultTimeout: 30000, autoUpdate: true }),
 }))
 
 import { registerOAuthHandlers } from '../oauth'
@@ -64,7 +64,7 @@ function invoke(channel: string, args: unknown) {
 describe('OAuth IPC handlers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetGeneralSettings.mockReturnValue({ sslVerification: true, followRedirects: true, defaultTimeout: 30000 })
+    mockGetGeneralSettings.mockReturnValue({ sslVerification: true, followRedirects: true, defaultTimeout: 30000, autoUpdate: true })
     registerOAuthHandlers()
   })
 
@@ -79,7 +79,7 @@ describe('OAuth IPC handlers', () => {
     })
 
     it('passes sslVerification=false to authorizeAuthCode when global SSL is disabled', async () => {
-      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000 })
+      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000, autoUpdate: true })
       mockQ1.mockReturnValue(fakeConfigRow)
       mockAuthorizeAuthCode.mockResolvedValue(fakeToken)
       await invoke('postly:oauth:authorize', { configId: 'cfg1' })
@@ -87,7 +87,7 @@ describe('OAuth IPC handlers', () => {
     })
 
     it('passes sslVerification=false to clientCredentials when global SSL is disabled', async () => {
-      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000 })
+      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000, autoUpdate: true })
       mockQ1.mockReturnValue({ ...fakeConfigRow, grant_type: 'client_credentials' })
       mockClientCredentials.mockResolvedValue(fakeToken)
       await invoke('postly:oauth:authorize', { configId: 'cfg1' })
@@ -111,7 +111,7 @@ describe('OAuth IPC handlers', () => {
     })
 
     it('passes sslVerification=false to getValidToken when global SSL is disabled', async () => {
-      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000 })
+      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000, autoUpdate: true })
       mockGetValidToken.mockResolvedValue(fakeToken)
       await invoke('postly:oauth:token:get', { configId: 'cfg1' })
       expect(mockGetValidToken).toHaveBeenCalledWith('cfg1', false)
@@ -128,7 +128,7 @@ describe('OAuth IPC handlers', () => {
     })
 
     it('passes sslVerification=false to authorizeInline when global SSL is disabled', async () => {
-      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000 })
+      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000, autoUpdate: true })
       mockAuthorizeInline.mockResolvedValue(fakeToken)
       await invoke('postly:oauth:inline:authorize', fakeOAuthConfig)
       expect(mockAuthorizeInline).toHaveBeenCalledWith(fakeOAuthConfig, false)
@@ -145,7 +145,7 @@ describe('OAuth IPC handlers', () => {
     })
 
     it('passes sslVerification=false to getValidTokenForConfig when global SSL is disabled', async () => {
-      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000 })
+      mockGetGeneralSettings.mockReturnValue({ sslVerification: false, followRedirects: true, defaultTimeout: 30000, autoUpdate: true })
       mockGetValidTokenForConfig.mockResolvedValue(fakeToken)
       await invoke('postly:oauth:inline:token:get', fakeOAuthConfig)
       expect(mockGetValidTokenForConfig).toHaveBeenCalledWith(fakeOAuthConfig, false)

--- a/src/main/ipc/__tests__/updater.test.ts
+++ b/src/main/ipc/__tests__/updater.test.ts
@@ -20,7 +20,8 @@ vi.mock('../../services/updater', () => ({
   checkForUpdates: vi.fn(),
   downloadUpdate: vi.fn(),
   installUpdate: vi.fn(),
-  setUpdateFeedUrl: vi.fn(),
+  applyFeedUrl: vi.fn(),
+  getEnterpriseConfig: vi.fn().mockReturnValue({}),
 }))
 
 import { registerUpdaterHandlers } from '../updater'
@@ -28,16 +29,19 @@ import {
   checkForUpdates,
   downloadUpdate,
   installUpdate,
-  setUpdateFeedUrl,
+  applyFeedUrl,
+  getEnterpriseConfig,
 } from '../../services/updater'
 
 const mockCheck = vi.mocked(checkForUpdates)
 const mockDownload = vi.mocked(downloadUpdate)
 const mockInstall = vi.mocked(installUpdate)
-const mockSetFeed = vi.mocked(setUpdateFeedUrl)
+const mockApplyFeed = vi.mocked(applyFeedUrl)
+const mockGetEnterprise = vi.mocked(getEnterpriseConfig)
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockGetEnterprise.mockReturnValue({})
   Object.keys(state.handlers).forEach((k) => delete state.handlers[k])
   registerUpdaterHandlers()
 })
@@ -45,11 +49,12 @@ beforeEach(() => {
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('registerUpdaterHandlers', () => {
-  it('registers all four IPC channels', () => {
+  it('registers all five IPC channels', () => {
     expect(state.handlers).toHaveProperty('postly:updater:check')
     expect(state.handlers).toHaveProperty('postly:updater:download')
     expect(state.handlers).toHaveProperty('postly:updater:install')
     expect(state.handlers).toHaveProperty('postly:updater:set-feed')
+    expect(state.handlers).toHaveProperty('postly:updater:get-enterprise-config')
   })
 
   describe('postly:updater:check', () => {
@@ -95,16 +100,40 @@ describe('registerUpdaterHandlers', () => {
   })
 
   describe('postly:updater:set-feed', () => {
-    it('calls setUpdateFeedUrl with the provided url', async () => {
+    it('calls applyFeedUrl with provided url when no enterprise config', async () => {
       const result = await state.handlers['postly:updater:set-feed'](null, { url: 'https://updates.example.com' })
-      expect(mockSetFeed).toHaveBeenCalledWith('https://updates.example.com')
+      expect(mockApplyFeed).toHaveBeenCalledWith('https://updates.example.com')
       expect(result).toEqual({ data: true })
     })
 
-    it('returns { error } when setUpdateFeedUrl throws', async () => {
-      mockSetFeed.mockImplementationOnce(() => { throw new Error('bad url') })
+    it('passes undefined to applyFeedUrl when url is empty (reverts to GitHub)', async () => {
+      await state.handlers['postly:updater:set-feed'](null, { url: '' })
+      expect(mockApplyFeed).toHaveBeenCalledWith(undefined)
+    })
+
+    it('skips applyFeedUrl when enterprise config is active', async () => {
+      mockGetEnterprise.mockReturnValueOnce({ updateUrl: 'https://corp.internal/postly/' })
+      await state.handlers['postly:updater:set-feed'](null, { url: 'https://other.com' })
+      expect(mockApplyFeed).not.toHaveBeenCalled()
+    })
+
+    it('returns { error } when applyFeedUrl throws', async () => {
+      mockApplyFeed.mockImplementationOnce(() => { throw new Error('bad url') })
       const result = await state.handlers['postly:updater:set-feed'](null, { url: 'bad' })
       expect(result).toEqual({ error: 'Error: bad url' })
+    })
+  })
+
+  describe('postly:updater:get-enterprise-config', () => {
+    it('returns the enterprise config', async () => {
+      mockGetEnterprise.mockReturnValueOnce({ updateUrl: 'https://corp.internal/postly/' })
+      const result = await state.handlers['postly:updater:get-enterprise-config'](null)
+      expect(result).toEqual({ data: { updateUrl: 'https://corp.internal/postly/' } })
+    })
+
+    it('returns empty object when no enterprise config', async () => {
+      const result = await state.handlers['postly:updater:get-enterprise-config'](null)
+      expect(result).toEqual({ data: {} })
     })
   })
 })

--- a/src/main/ipc/__tests__/updater.test.ts
+++ b/src/main/ipc/__tests__/updater.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Capture IPC handlers ─────────────────────────────────────────────────────
+
+const state: { handlers: Record<string, (ev: unknown, args?: unknown) => Promise<unknown>> } = {
+  handlers: {},
+}
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((ch: string, fn: (ev: unknown, args?: unknown) => Promise<unknown>) => {
+      state.handlers[ch] = fn
+    }),
+  },
+}))
+
+// ─── Mock updater service ─────────────────────────────────────────────────────
+
+vi.mock('../../services/updater', () => ({
+  checkForUpdates: vi.fn(),
+  downloadUpdate: vi.fn(),
+  installUpdate: vi.fn(),
+  setUpdateFeedUrl: vi.fn(),
+}))
+
+import { registerUpdaterHandlers } from '../updater'
+import {
+  checkForUpdates,
+  downloadUpdate,
+  installUpdate,
+  setUpdateFeedUrl,
+} from '../../services/updater'
+
+const mockCheck = vi.mocked(checkForUpdates)
+const mockDownload = vi.mocked(downloadUpdate)
+const mockInstall = vi.mocked(installUpdate)
+const mockSetFeed = vi.mocked(setUpdateFeedUrl)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.keys(state.handlers).forEach((k) => delete state.handlers[k])
+  registerUpdaterHandlers()
+})
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('registerUpdaterHandlers', () => {
+  it('registers all four IPC channels', () => {
+    expect(state.handlers).toHaveProperty('postly:updater:check')
+    expect(state.handlers).toHaveProperty('postly:updater:download')
+    expect(state.handlers).toHaveProperty('postly:updater:install')
+    expect(state.handlers).toHaveProperty('postly:updater:set-feed')
+  })
+
+  describe('postly:updater:check', () => {
+    it('calls checkForUpdates and returns { data: true }', async () => {
+      const result = await state.handlers['postly:updater:check'](null)
+      expect(mockCheck).toHaveBeenCalledOnce()
+      expect(result).toEqual({ data: true })
+    })
+
+    it('returns { error } when checkForUpdates throws', async () => {
+      mockCheck.mockImplementationOnce(() => { throw new Error('check failed') })
+      const result = await state.handlers['postly:updater:check'](null)
+      expect(result).toEqual({ error: 'Error: check failed' })
+    })
+  })
+
+  describe('postly:updater:download', () => {
+    it('calls downloadUpdate and returns { data: true }', async () => {
+      const result = await state.handlers['postly:updater:download'](null)
+      expect(mockDownload).toHaveBeenCalledOnce()
+      expect(result).toEqual({ data: true })
+    })
+
+    it('returns { error } when downloadUpdate throws', async () => {
+      mockDownload.mockImplementationOnce(() => { throw new Error('download failed') })
+      const result = await state.handlers['postly:updater:download'](null)
+      expect(result).toEqual({ error: 'Error: download failed' })
+    })
+  })
+
+  describe('postly:updater:install', () => {
+    it('calls installUpdate and returns { data: true }', async () => {
+      const result = await state.handlers['postly:updater:install'](null)
+      expect(mockInstall).toHaveBeenCalledOnce()
+      expect(result).toEqual({ data: true })
+    })
+
+    it('returns { error } when installUpdate throws', async () => {
+      mockInstall.mockImplementationOnce(() => { throw new Error('install failed') })
+      const result = await state.handlers['postly:updater:install'](null)
+      expect(result).toEqual({ error: 'Error: install failed' })
+    })
+  })
+
+  describe('postly:updater:set-feed', () => {
+    it('calls setUpdateFeedUrl with the provided url', async () => {
+      const result = await state.handlers['postly:updater:set-feed'](null, { url: 'https://updates.example.com' })
+      expect(mockSetFeed).toHaveBeenCalledWith('https://updates.example.com')
+      expect(result).toEqual({ data: true })
+    })
+
+    it('returns { error } when setUpdateFeedUrl throws', async () => {
+      mockSetFeed.mockImplementationOnce(() => { throw new Error('bad url') })
+      const result = await state.handlers['postly:updater:set-feed'](null, { url: 'bad' })
+      expect(result).toEqual({ error: 'Error: bad url' })
+    })
+  })
+})

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -16,6 +16,7 @@ import { registerAiHandlers } from './ai'
 import { registerExportImportHandlers } from './export-import'
 import { registerDraftHandlers } from './drafts'
 import { registerWindowHandlers } from './window'
+import { registerUpdaterHandlers } from './updater'
 
 export { attachWindowEvents } from './window'
 
@@ -38,4 +39,5 @@ export function registerAllIpcHandlers(): void {
   registerExportImportHandlers()
   registerDraftHandlers()
   registerWindowHandlers()
+  registerUpdaterHandlers()
 }

--- a/src/main/ipc/settings-utils.ts
+++ b/src/main/ipc/settings-utils.ts
@@ -4,12 +4,16 @@ export type GeneralSettings = {
   sslVerification: boolean
   followRedirects: boolean
   defaultTimeout: number
+  autoUpdate: boolean
+  updateFeedUrl?: string
 }
 
 const GENERAL_DEFAULTS: GeneralSettings = {
   sslVerification: true,
   followRedirects: true,
   defaultTimeout: 30000,
+  autoUpdate: true,
+  updateFeedUrl: undefined,
 }
 
 export function parseGeneralSettings(value: string | undefined): GeneralSettings {
@@ -20,6 +24,8 @@ export function parseGeneralSettings(value: string | undefined): GeneralSettings
     if (typeof parsed['sslVerification'] === 'boolean') result.sslVerification = parsed['sslVerification']
     if (typeof parsed['followRedirects'] === 'boolean') result.followRedirects = parsed['followRedirects']
     if (typeof parsed['defaultTimeout'] === 'number') result.defaultTimeout = parsed['defaultTimeout']
+    if (typeof parsed['autoUpdate'] === 'boolean') result.autoUpdate = parsed['autoUpdate']
+    if (typeof parsed['updateFeedUrl'] === 'string') result.updateFeedUrl = parsed['updateFeedUrl'] || undefined
   } catch { /* use defaults */ }
   return result
 }

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron'
 import { queryAll, queryOne, run } from '../database'
 
 const DEFAULTS = {
-  general: { theme: 'dark', defaultTimeout: 30000, followRedirects: true, sslVerification: true },
+  general: { theme: 'dark', defaultTimeout: 30000, followRedirects: true, sslVerification: true, autoUpdate: true },
   backstage: { baseUrl: '', token: '', autoSync: false },
   github: { token: '', orgs: [] as string[] },
   gitlab: { baseUrl: 'https://gitlab.com', token: '', groups: [] as string[] },

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import { checkForUpdates, downloadUpdate, installUpdate, setUpdateFeedUrl } from '../services/updater'
+import { checkForUpdates, downloadUpdate, installUpdate, applyFeedUrl, getEnterpriseConfig } from '../services/updater'
 
 export function registerUpdaterHandlers(): void {
   ipcMain.handle('postly:updater:check', () => {
@@ -31,8 +31,20 @@ export function registerUpdaterHandlers(): void {
 
   ipcMain.handle('postly:updater:set-feed', (_, args: { url: string }) => {
     try {
-      setUpdateFeedUrl(args.url)
+      // Enterprise bundled config always wins — user cannot override it
+      const enterprise = getEnterpriseConfig()
+      if (!enterprise.updateUrl) {
+        applyFeedUrl(args.url || undefined)
+      }
       return { data: true }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+
+  ipcMain.handle('postly:updater:get-enterprise-config', () => {
+    try {
+      return { data: getEnterpriseConfig() }
     } catch (err) {
       return { error: String(err) }
     }

--- a/src/main/ipc/updater.ts
+++ b/src/main/ipc/updater.ts
@@ -1,0 +1,40 @@
+import { ipcMain } from 'electron'
+import { checkForUpdates, downloadUpdate, installUpdate, setUpdateFeedUrl } from '../services/updater'
+
+export function registerUpdaterHandlers(): void {
+  ipcMain.handle('postly:updater:check', () => {
+    try {
+      checkForUpdates()
+      return { data: true }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+
+  ipcMain.handle('postly:updater:download', () => {
+    try {
+      downloadUpdate()
+      return { data: true }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+
+  ipcMain.handle('postly:updater:install', () => {
+    try {
+      installUpdate()
+      return { data: true }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+
+  ipcMain.handle('postly:updater:set-feed', (_, args: { url: string }) => {
+    try {
+      setUpdateFeedUrl(args.url)
+      return { data: true }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+}

--- a/src/main/services/__tests__/updater.integration.test.ts
+++ b/src/main/services/__tests__/updater.integration.test.ts
@@ -643,7 +643,7 @@ describe('getEnterpriseConfig — real filesystem', () => {
   })
 
   afterEach(() => {
-    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = originalResourcesPath
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = originalResourcesPath as string
     fs.rmSync(tmpDir, { recursive: true, force: true })
   })
 
@@ -676,7 +676,7 @@ describe('getEnterpriseConfig — real filesystem', () => {
   })
 
   it('returns empty config when resourcesPath is not set', () => {
-    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = undefined
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = undefined as unknown as string
 
     const result = getEnterpriseConfig()
 

--- a/src/main/services/__tests__/updater.integration.test.ts
+++ b/src/main/services/__tests__/updater.integration.test.ts
@@ -1,0 +1,713 @@
+/**
+ * Integration tests for the enterprise update flow using Mockly as the
+ * real HTTP update server.
+ *
+ * electron-updater cannot run in a Node test environment (it requires a
+ * packaged Electron app). We replace it via __setAutoUpdaterForTesting with
+ * a lightweight HTTP shim that makes real network requests to a Mockly server
+ * and fires the same events electron-updater would. This lets us exercise the
+ * full event-forwarding pipeline against a real HTTP server.
+ *
+ * Scenarios covered:
+ *   • Update available    — server returns a newer version in latest.yml
+ *   • No update           — server returns the current version
+ *   • Server errors       — 404, 503, connection refused
+ *   • Download flow       — manifest fetch → binary fetch → downloaded event
+ *   • Download progress   — progress event fires mid-download
+ *   • Fault injection     — slow server, all-503 scenario
+ *   • Enterprise URL      — applyFeedUrl() correctly routes requests
+ *   • Enterprise config   — getEnterpriseConfig() reads enterprise.json from disk
+ *
+ * Prerequisites: run `node scripts/download-mockly.mjs` to download the binary.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import os from 'os'
+import fs from 'fs'
+import path from 'path'
+import type { BrowserWindow } from 'electron'
+import { MocklyServer, getFreePort } from './helpers/mockly'
+import type { UpdaterEvent } from '../updater'
+
+// ─── Mock electron ─────────────────────────────────────────────────────────────
+//
+// isPackaged = true so that initUpdater registers listeners and
+// applyFeedUrl / checkForUpdates use the real (shim) code path.
+
+const CURRENT_VERSION = '1.0.0'
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getVersion: vi.fn(() => CURRENT_VERSION),
+  },
+  BrowserWindow: vi.fn(),
+}))
+
+// ─── Real-HTTP autoUpdater shim ─────────────────────────────────────────────────
+//
+// Implements the same interface as electron-updater's autoUpdater. Instead of
+// talking to GitHub (or any provider) via native Electron code, it makes plain
+// fetch() calls against whatever URL was set via setFeedURL(). Events are fired
+// in the same sequence as electron-updater would fire them, so the service's
+// event-forwarding logic is exercised end-to-end.
+
+type EventHandler = (...args: unknown[]) => void
+
+class RealHttpAutoUpdater {
+  autoDownload = false
+  autoInstallOnAppQuit = false
+  logger: unknown = null
+
+  private feedUrl = ''
+  private handlers: Record<string, EventHandler[]> = {}
+
+  on(event: string, handler: EventHandler): void {
+    (this.handlers[event] ??= []).push(handler)
+  }
+
+  setFeedURL(opts: Record<string, unknown>): void {
+    if (typeof opts.url === 'string') {
+      this.feedUrl = opts.url.replace(/\/$/, '')
+    } else if (opts.provider === 'github') {
+      // GitHub provider — mark as such; real download path not tested here
+      this.feedUrl = '__github__'
+    }
+  }
+
+  getConfiguredUrl(): string {
+    return this.feedUrl
+  }
+
+  async checkForUpdates(): Promise<void> {
+    // 'checking-for-update' fires before the HTTP round-trip (mirrors real behaviour)
+    this._emit('checking-for-update')
+
+    if (!this.feedUrl || this.feedUrl === '__github__') {
+      this._emit('update-not-available', { version: CURRENT_VERSION })
+      return
+    }
+
+    let res: Response
+    try {
+      res = await fetch(`${this.feedUrl}/latest.yml`, { signal: AbortSignal.timeout(5000) })
+    } catch (err) {
+      this._emit('error', err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+
+    if (!res.ok) {
+      this._emit('error', new Error(`Update server returned HTTP ${res.status}`))
+      return
+    }
+
+    try {
+      const text = await res.text()
+      const version = (text.match(/^version:\s*(.+)/m)?.[1] ?? '').trim()
+
+      if (version && version !== CURRENT_VERSION) {
+        this._emit('update-available', { version })
+      } else {
+        this._emit('update-not-available', { version })
+      }
+    } catch (err) {
+      this._emit('error', err instanceof Error ? err : new Error(String(err)))
+    }
+  }
+
+  async downloadUpdate(): Promise<void> {
+    if (!this.feedUrl || this.feedUrl === '__github__') return
+
+    let res: Response
+    try {
+      res = await fetch(`${this.feedUrl}/latest.yml`)
+    } catch (err) {
+      this._emit('error', err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+
+    if (!res.ok) {
+      this._emit('error', new Error(`Manifest fetch failed: HTTP ${res.status}`))
+      return
+    }
+
+    const text = await res.text()
+    const filename = (text.match(/^path:\s*(.+)/m)?.[1] ?? '').trim()
+    const version = (text.match(/^version:\s*(.+)/m)?.[1] ?? '').trim()
+
+    if (!filename) {
+      this._emit('error', new Error('No path field in update manifest'))
+      return
+    }
+
+    this._emit('download-progress', { percent: 50 })
+
+    let fileRes: Response
+    try {
+      fileRes = await fetch(`${this.feedUrl}/${filename}`)
+    } catch (err) {
+      this._emit('error', err instanceof Error ? err : new Error(String(err)))
+      return
+    }
+
+    if (!fileRes.ok) {
+      this._emit('error', new Error(`Binary download failed: HTTP ${fileRes.status}`))
+      return
+    }
+
+    this._emit('update-downloaded', { version })
+  }
+
+  quitAndInstall(_isSilent: boolean, _isForceRunAfter: boolean): void {
+    /* no-op in tests */
+  }
+
+  private _emit(event: string, ...args: unknown[]): void {
+    this.handlers[event]?.forEach((h) => h(...args))
+  }
+}
+
+// ─── Event capture ─────────────────────────────────────────────────────────────
+//
+// Events emitted via win.webContents.send('postly:updater:event', payload) are
+// buffered. waitForEvent() dequeues the first matching event or waits for one
+// to arrive, whichever comes first.
+
+const eventQueue: UpdaterEvent[] = []
+const eventWaiters: Array<{
+  type: UpdaterEvent['type']
+  resolve: (e: UpdaterEvent) => void
+  reject: (e: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}> = []
+
+function captureEvent(event: UpdaterEvent): void {
+  const idx = eventWaiters.findIndex((w) => w.type === event.type)
+  if (idx >= 0) {
+    const [waiter] = eventWaiters.splice(idx, 1)
+    clearTimeout(waiter.timer)
+    waiter.resolve(event)
+  } else {
+    eventQueue.push(event)
+  }
+}
+
+function waitForEvent(type: UpdaterEvent['type'], timeoutMs = 5000): Promise<UpdaterEvent> {
+  const existing = eventQueue.findIndex((e) => e.type === type)
+  if (existing >= 0) {
+    return Promise.resolve(eventQueue.splice(existing, 1)[0])
+  }
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const i = eventWaiters.findIndex((w) => w.resolve === resolve)
+      if (i >= 0) eventWaiters.splice(i, 1)
+      reject(new Error(`Timed out waiting for updater event: ${type}`))
+    }, timeoutMs)
+    eventWaiters.push({ type, resolve, reject, timer })
+  })
+}
+
+// ─── Mock BrowserWindow ────────────────────────────────────────────────────────
+
+const mockWebContentsSend = vi.fn().mockImplementation((channel: string, data: unknown) => {
+  if (channel === 'postly:updater:event') captureEvent(data as UpdaterEvent)
+})
+
+const mockWin = {
+  webContents: { send: mockWebContentsSend },
+  isDestroyed: vi.fn().mockReturnValue(false),
+} as unknown as BrowserWindow
+
+// ─── latest.yml builder ─────────────────────────────────────────────────────────
+
+function makeLatestYml(version: string, filename = `postly-${version}.zip`): string {
+  return [
+    `version: ${version}`,
+    `files:`,
+    `  - url: ${filename}`,
+    `    sha512: abc123def456abc123def456`,
+    `    size: 104857600`,
+    `path: ${filename}`,
+    `sha512: abc123def456abc123def456`,
+    `releaseDate: '2025-01-01T00:00:00.000Z'`,
+  ].join('\n')
+}
+
+// ─── Module references (populated in beforeAll) ────────────────────────────────
+
+let applyFeedUrl: (url: string | undefined) => void
+let checkForUpdates: () => void
+let downloadUpdate: () => void
+let getEnterpriseConfig: () => { updateUrl?: string }
+let shim: RealHttpAutoUpdater
+let server: MocklyServer
+
+// ─── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  server = await MocklyServer.create({
+    scenarios: [
+      {
+        id: 'server-down',
+        name: 'Update server returns 503',
+        patches: [{ mock_id: 'latest-yml', status: 503, body: 'Service Unavailable' }],
+      },
+    ],
+  })
+
+  shim = new RealHttpAutoUpdater()
+
+  // Dynamic import ensures the electron mock is active before the module loads
+  const mod = await import('../updater')
+  mod.__setAutoUpdaterForTesting(shim as never)
+  mod.initUpdater(mockWin)
+
+  applyFeedUrl = mod.applyFeedUrl
+  checkForUpdates = mod.checkForUpdates
+  downloadUpdate = mod.downloadUpdate
+  getEnterpriseConfig = mod.getEnterpriseConfig
+}, 30_000)
+
+afterAll(() => server?.stop())
+
+beforeEach(async () => {
+  eventQueue.length = 0
+  eventWaiters.length = 0
+  mockWebContentsSend.mockClear()
+  await server.reset()
+})
+
+// ─── Update availability ────────────────────────────────────────────────────────
+
+describe('update available', () => {
+  it('fires checking then available when server returns newer version', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+
+    const checking = await waitForEvent('checking')
+    expect(checking.type).toBe('checking')
+
+    const available = await waitForEvent('available')
+    expect(available.type).toBe('available')
+    expect(available.version).toBe('2.0.0')
+  })
+
+  it('includes the version from the manifest in the available event', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('3.1.4'),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+
+    const available = await waitForEvent('available')
+    expect(available.version).toBe('3.1.4')
+  })
+})
+
+// ─── No update available ────────────────────────────────────────────────────────
+
+describe('no update available', () => {
+  it('fires checking then not-available when server returns current version', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml(CURRENT_VERSION),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+
+    const checking = await waitForEvent('checking')
+    expect(checking.type).toBe('checking')
+
+    const notAvailable = await waitForEvent('not-available')
+    expect(notAvailable.type).toBe('not-available')
+  })
+})
+
+// ─── Server error handling ──────────────────────────────────────────────────────
+
+describe('server error handling', () => {
+  it('fires error event when latest.yml returns 404', async () => {
+    await server.addMock({
+      id: 'latest-yml-404',
+      request: { method: 'GET', path: '/404/latest.yml' },
+      response: { status: 404, body: 'Not Found' },
+    })
+
+    applyFeedUrl(`${server.httpBase}/404`)
+    checkForUpdates()
+
+    const error = await waitForEvent('error')
+    expect(error.type).toBe('error')
+    expect(error.error).toMatch(/404/)
+  })
+
+  it('fires error event when server returns 503', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: { status: 503, body: 'Service Unavailable' },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+
+    const error = await waitForEvent('error')
+    expect(error.type).toBe('error')
+    expect(error.error).toMatch(/503/)
+  })
+
+  it('fires error event when server is unreachable (connection refused)', async () => {
+    const deadPort = await getFreePort()
+
+    applyFeedUrl(`http://127.0.0.1:${deadPort}`)
+    checkForUpdates()
+
+    const error = await waitForEvent('error')
+    expect(error.type).toBe('error')
+    expect(error.error).toBeTruthy()
+  })
+})
+
+// ─── Fault injection ───────────────────────────────────────────────────────────
+
+describe('fault injection', () => {
+  it('fires error event when scenario activates 503 on the update endpoint', async () => {
+    // 'latest-yml' mock must exist for the scenario patch to apply
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    // Without scenario: update is available
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+    const first = await waitForEvent('available')
+    expect(first.version).toBe('2.0.0')
+
+    // Activate the server-down scenario
+    await server.activateScenario('server-down')
+
+    checkForUpdates()
+    const error = await waitForEvent('error')
+    expect(error.type).toBe('error')
+    expect(error.error).toMatch(/503/)
+  })
+
+  it('still returns update event when server adds a small delay', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        delay: '100ms',
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+
+    const available = await waitForEvent('available', 6000)
+    expect(available.version).toBe('2.0.0')
+  })
+})
+
+// ─── Update download flow ───────────────────────────────────────────────────────
+
+describe('downloadUpdate', () => {
+  it('fetches binary from update server and fires downloaded event', async () => {
+    const version = '2.0.0'
+    const filename = `postly-${version}.zip`
+
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml(version, filename),
+      },
+    })
+
+    await server.addMock({
+      id: 'binary',
+      request: { method: 'GET', path: `/${filename}` },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: 'binary-content',
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    downloadUpdate()
+
+    const progress = await waitForEvent('progress')
+    expect(progress.type).toBe('progress')
+    expect(progress.percent).toBe(50)
+
+    const downloaded = await waitForEvent('downloaded')
+    expect(downloaded.type).toBe('downloaded')
+    expect(downloaded.version).toBe(version)
+  })
+
+  it('fires error event when binary is not found on server', async () => {
+    const version = '2.0.0'
+    const filename = `postly-${version}.zip`
+
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml(version, filename),
+      },
+    })
+
+    await server.addMock({
+      id: 'binary-missing',
+      request: { method: 'GET', path: `/${filename}` },
+      response: { status: 404, body: 'Not Found' },
+    })
+
+    applyFeedUrl(server.httpBase)
+    downloadUpdate()
+
+    const error = await waitForEvent('error')
+    expect(error.type).toBe('error')
+    expect(error.error).toMatch(/404/)
+  })
+
+  it('fires error event when manifest returns 404 during download', async () => {
+    await server.addMock({
+      id: 'latest-yml-missing',
+      request: { method: 'GET', path: '/missing/latest.yml' },
+      response: { status: 404, body: 'Not Found' },
+    })
+
+    applyFeedUrl(`${server.httpBase}/missing`)
+    downloadUpdate()
+
+    const error = await waitForEvent('error')
+    expect(error.type).toBe('error')
+    expect(error.error).toMatch(/404/)
+  })
+
+  it('verifies update server received the manifest and binary requests', async () => {
+    const version = '2.1.0'
+    const filename = `postly-${version}.zip`
+
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml(version, filename),
+      },
+    })
+    await server.addMock({
+      id: 'binary',
+      request: { method: 'GET', path: `/${filename}` },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+        body: 'fake-binary',
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    downloadUpdate()
+    await waitForEvent('downloaded')
+
+    const manifestCalls = await server.getCalls('latest-yml')
+    expect(manifestCalls.count).toBeGreaterThanOrEqual(1)
+
+    const binaryCalls = await server.getCalls('binary')
+    expect(binaryCalls.count).toBe(1)
+    expect(binaryCalls.calls[0].path).toBe(`/${filename}`)
+  })
+})
+
+// ─── Enterprise URL routing ─────────────────────────────────────────────────────
+
+describe('enterprise URL routing', () => {
+  it('routes update checks to the configured enterprise server URL', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+    await waitForEvent('available')
+
+    const calls = await server.getCalls('latest-yml')
+    expect(calls.count).toBeGreaterThanOrEqual(1)
+  })
+
+  it('reverts to GitHub provider (not the enterprise server) when URL is cleared', () => {
+    applyFeedUrl(undefined)
+
+    // Shim records provider=github as '__github__' — no requests to our server
+    expect(shim.getConfiguredUrl()).toBe('__github__')
+  })
+
+  it('updates the feed URL when applyFeedUrl is called again', async () => {
+    // First URL
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    expect(shim.getConfiguredUrl()).toBe(server.httpBase)
+
+    // Switch to a dead URL
+    applyFeedUrl('http://127.0.0.1:1')
+    expect(shim.getConfiguredUrl()).toBe('http://127.0.0.1:1')
+  })
+
+  it('enterprise mirror request includes the correct path (latest.yml)', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    applyFeedUrl(server.httpBase)
+    checkForUpdates()
+    await waitForEvent('available')
+
+    const calls = await server.getCalls('latest-yml')
+    const call = calls.calls[0]
+    expect(call.path).toBe('/latest.yml')
+    expect(call.method).toBe('GET')
+  })
+})
+
+// ─── getEnterpriseConfig file reading ──────────────────────────────────────────
+
+describe('getEnterpriseConfig — real filesystem', () => {
+  let tmpDir: string
+  let originalResourcesPath: string | undefined
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'postly-enterprise-test-'))
+    originalResourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+  })
+
+  afterEach(() => {
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = originalResourcesPath
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns the updateUrl from enterprise.json when resourcesPath is set', () => {
+    const config = { updateUrl: 'https://updates.internal.corp/postly/' }
+    fs.writeFileSync(path.join(tmpDir, 'enterprise.json'), JSON.stringify(config))
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = tmpDir
+
+    const result = getEnterpriseConfig()
+
+    expect(result.updateUrl).toBe('https://updates.internal.corp/postly/')
+  })
+
+  it('returns empty config when enterprise.json does not exist', () => {
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = tmpDir
+    // No enterprise.json written
+
+    const result = getEnterpriseConfig()
+
+    expect(result).toEqual({})
+  })
+
+  it('returns empty config when enterprise.json contains malformed JSON', () => {
+    fs.writeFileSync(path.join(tmpDir, 'enterprise.json'), '{ invalid json }')
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = tmpDir
+
+    const result = getEnterpriseConfig()
+
+    expect(result).toEqual({})
+  })
+
+  it('returns empty config when resourcesPath is not set', () => {
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = undefined
+
+    const result = getEnterpriseConfig()
+
+    expect(result).toEqual({})
+  })
+
+  it('applies the enterprise URL to the update feed when config is present', async () => {
+    await server.addMock({
+      id: 'latest-yml',
+      request: { method: 'GET', path: '/latest.yml' },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'text/plain' },
+        body: makeLatestYml('2.0.0'),
+      },
+    })
+
+    // Write enterprise config pointing to our mockly server
+    const config = { updateUrl: server.httpBase }
+    fs.writeFileSync(path.join(tmpDir, 'enterprise.json'), JSON.stringify(config))
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = tmpDir
+
+    const enterprise = getEnterpriseConfig()
+    applyFeedUrl(enterprise.updateUrl)
+    checkForUpdates()
+
+    const available = await waitForEvent('available')
+    expect(available.version).toBe('2.0.0')
+
+    // The mockly server was hit via the enterprise URL
+    const calls = await server.getCalls('latest-yml')
+    expect(calls.count).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/src/main/services/__tests__/updater.test.ts
+++ b/src/main/services/__tests__/updater.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ─── Module-level state ───────────────────────────────────────────────────────
+let isPackaged = false
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock('electron', () => ({
+  app: {
+    get isPackaged() {
+      return isPackaged
+    },
+  },
+}))
+
+// ─── Fake BrowserWindow ───────────────────────────────────────────────────────
+
+const mockSend = vi.fn()
+const mockIsDestroyed = vi.fn().mockReturnValue(false)
+const mockWin = { webContents: { send: mockSend }, isDestroyed: mockIsDestroyed }
+
+// ─── Fake autoUpdater ─────────────────────────────────────────────────────────
+
+const auListeners: Record<string, Array<(...args: unknown[]) => void>> = {}
+const mockAutoUpdater = {
+  autoDownload: true,
+  autoInstallOnAppQuit: false,
+  logger: undefined as unknown,
+  on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    auListeners[event] = auListeners[event] ?? []
+    auListeners[event].push(handler)
+  }),
+  checkForUpdates: vi.fn().mockResolvedValue(undefined),
+  downloadUpdate: vi.fn().mockResolvedValue(undefined),
+  quitAndInstall: vi.fn(),
+  setFeedURL: vi.fn(),
+}
+
+function fireAuEvent(event: string, ...args: unknown[]) {
+  for (const h of auListeners[event] ?? []) h(...args)
+}
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import {
+  initUpdater,
+  checkForUpdates,
+  downloadUpdate,
+  installUpdate,
+  setUpdateFeedUrl,
+  __setAutoUpdaterForTesting,
+} from '../updater'
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockIsDestroyed.mockReturnValue(false)
+  Object.keys(auListeners).forEach((k) => delete auListeners[k])
+  mockAutoUpdater.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+    auListeners[event] = auListeners[event] ?? []
+    auListeners[event].push(handler)
+  })
+  __setAutoUpdaterForTesting(mockAutoUpdater)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  __setAutoUpdaterForTesting(null)
+})
+
+// ─── Dev mode (not packaged) ──────────────────────────────────────────────────
+
+describe('dev mode (not packaged)', () => {
+  beforeEach(() => {
+    isPackaged = false
+    initUpdater(mockWin as never)
+  })
+
+  it('initUpdater does not configure autoUpdater', () => {
+    expect(mockAutoUpdater.on).not.toHaveBeenCalled()
+  })
+
+  it('checkForUpdates emits "checking" immediately', () => {
+    vi.useFakeTimers()
+    checkForUpdates()
+    expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'checking' })
+  })
+
+  it('checkForUpdates emits "not-available" after 800ms', () => {
+    vi.useFakeTimers()
+    checkForUpdates()
+    vi.advanceTimersByTime(800)
+    expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'not-available' })
+  })
+
+  it('checkForUpdates does not call autoUpdater.checkForUpdates', () => {
+    vi.useFakeTimers()
+    checkForUpdates()
+    vi.advanceTimersByTime(800)
+    expect(mockAutoUpdater.checkForUpdates).not.toHaveBeenCalled()
+  })
+
+  it('downloadUpdate is a no-op', () => {
+    downloadUpdate()
+    expect(mockAutoUpdater.downloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it('installUpdate is a no-op', () => {
+    installUpdate()
+    expect(mockAutoUpdater.quitAndInstall).not.toHaveBeenCalled()
+  })
+
+  it('setUpdateFeedUrl is a no-op', () => {
+    setUpdateFeedUrl('https://updates.example.com')
+    expect(mockAutoUpdater.setFeedURL).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Packaged mode ────────────────────────────────────────────────────────────
+
+describe('packaged mode', () => {
+  beforeEach(() => {
+    isPackaged = true
+    initUpdater(mockWin as never)
+  })
+
+  it('initUpdater disables auto-download', () => {
+    expect(mockAutoUpdater.autoDownload).toBe(false)
+  })
+
+  it('initUpdater enables auto-install on quit', () => {
+    expect(mockAutoUpdater.autoInstallOnAppQuit).toBe(true)
+  })
+
+  it('initUpdater registers all autoUpdater event listeners', () => {
+    const events = mockAutoUpdater.on.mock.calls.map(([ev]) => ev)
+    expect(events).toContain('checking-for-update')
+    expect(events).toContain('update-available')
+    expect(events).toContain('update-not-available')
+    expect(events).toContain('download-progress')
+    expect(events).toContain('update-downloaded')
+    expect(events).toContain('error')
+  })
+
+  it('checkForUpdates delegates to autoUpdater', () => {
+    checkForUpdates()
+    expect(mockAutoUpdater.checkForUpdates).toHaveBeenCalledOnce()
+  })
+
+  it('downloadUpdate delegates to autoUpdater', () => {
+    downloadUpdate()
+    expect(mockAutoUpdater.downloadUpdate).toHaveBeenCalledOnce()
+  })
+
+  it('installUpdate calls quitAndInstall(false, true)', () => {
+    installUpdate()
+    expect(mockAutoUpdater.quitAndInstall).toHaveBeenCalledWith(false, true)
+  })
+
+  it('setUpdateFeedUrl calls setFeedURL with generic provider', () => {
+    setUpdateFeedUrl('https://updates.example.com/postly/')
+    expect(mockAutoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://updates.example.com/postly/',
+    })
+  })
+
+  describe('event forwarding to renderer', () => {
+    it('forwards checking-for-update → { type: "checking" }', () => {
+      fireAuEvent('checking-for-update')
+      expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'checking' })
+    })
+
+    it('forwards update-available → { type: "available", version }', () => {
+      fireAuEvent('update-available', { version: '2.0.0' })
+      expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'available', version: '2.0.0' })
+    })
+
+    it('forwards update-not-available → { type: "not-available" }', () => {
+      fireAuEvent('update-not-available')
+      expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'not-available' })
+    })
+
+    it('forwards download-progress → percent rounded to integer', () => {
+      fireAuEvent('download-progress', { percent: 45.7 })
+      expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'progress', percent: 46 })
+    })
+
+    it('forwards update-downloaded → { type: "downloaded", version }', () => {
+      fireAuEvent('update-downloaded', { version: '2.0.0' })
+      expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'downloaded', version: '2.0.0' })
+    })
+
+    it('forwards error → { type: "error", error: message }', () => {
+      fireAuEvent('error', new Error('network timeout'))
+      expect(mockSend).toHaveBeenCalledWith('postly:updater:event', { type: 'error', error: 'network timeout' })
+    })
+
+    it('does not emit to a destroyed window', () => {
+      mockIsDestroyed.mockReturnValue(true)
+      fireAuEvent('checking-for-update')
+      expect(mockSend).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/main/services/__tests__/updater.test.ts
+++ b/src/main/services/__tests__/updater.test.ts
@@ -48,6 +48,7 @@ import {
   downloadUpdate,
   installUpdate,
   setUpdateFeedUrl,
+  applyFeedUrl,
   __setAutoUpdaterForTesting,
 } from '../updater'
 
@@ -202,5 +203,75 @@ describe('packaged mode', () => {
       fireAuEvent('checking-for-update')
       expect(mockSend).not.toHaveBeenCalled()
     })
+  })
+})
+
+// ─── applyFeedUrl ─────────────────────────────────────────────────────────────
+
+describe('applyFeedUrl', () => {
+  beforeEach(() => {
+    isPackaged = true
+    initUpdater(mockWin as never)
+  })
+
+  it('sets generic provider when URL provided', () => {
+    applyFeedUrl('https://updates.internal.corp/postly/')
+    expect(mockAutoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'generic',
+      url: 'https://updates.internal.corp/postly/',
+    })
+  })
+
+  it('reverts to GitHub provider when URL is undefined', () => {
+    applyFeedUrl(undefined)
+    expect(mockAutoUpdater.setFeedURL).toHaveBeenCalledWith({
+      provider: 'github',
+      owner: 'dever-labs',
+      repo: 'postly',
+    })
+  })
+
+  it('is a no-op in dev mode', () => {
+    isPackaged = false
+    applyFeedUrl('https://updates.internal.corp/postly/')
+    expect(mockAutoUpdater.setFeedURL).not.toHaveBeenCalled()
+  })
+})
+
+// ─── getEnterpriseConfig ──────────────────────────────────────────────────────
+
+import { getEnterpriseConfig } from '../updater'
+import fs from 'fs'
+import path from 'path'
+
+describe('getEnterpriseConfig', () => {
+  it('returns empty object when resourcesPath is not set', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proc = process as any
+    const original = proc.resourcesPath
+    proc.resourcesPath = undefined
+    expect(getEnterpriseConfig()).toEqual({})
+    proc.resourcesPath = original
+  })
+
+  it('returns empty object when enterprise.json does not exist', () => {
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = '/tmp/no-such-dir-12345'
+    expect(getEnterpriseConfig()).toEqual({})
+  })
+
+  it('parses enterprise.json when present', () => {
+    const dir = fs.mkdtempSync('/tmp/postly-test-')
+    fs.writeFileSync(path.join(dir, 'enterprise.json'), JSON.stringify({ updateUrl: 'https://corp.internal/postly/' }))
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = dir
+    expect(getEnterpriseConfig()).toEqual({ updateUrl: 'https://corp.internal/postly/' })
+    fs.rmSync(dir, { recursive: true })
+  })
+
+  it('returns empty object when enterprise.json is malformed', () => {
+    const dir = fs.mkdtempSync('/tmp/postly-test-')
+    fs.writeFileSync(path.join(dir, 'enterprise.json'), 'not valid json')
+    ;(process as NodeJS.Process & { resourcesPath?: string }).resourcesPath = dir
+    expect(getEnterpriseConfig()).toEqual({})
+    fs.rmSync(dir, { recursive: true })
   })
 })

--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -1,4 +1,6 @@
 import { app, BrowserWindow } from 'electron'
+import fs from 'fs'
+import path from 'path'
 
 export type UpdaterEventType = 'checking' | 'available' | 'not-available' | 'progress' | 'downloaded' | 'error'
 
@@ -9,6 +11,12 @@ export interface UpdaterEvent {
   error?: string
 }
 
+export interface EnterpriseConfig {
+  /** Override the update feed with an internal mirror URL. When present,
+   *  the generic provider is used instead of GitHub Releases. */
+  updateUrl?: string
+}
+
 type AutoUpdater = {
   autoDownload: boolean
   autoInstallOnAppQuit: boolean
@@ -17,16 +25,18 @@ type AutoUpdater = {
   checkForUpdates(): Promise<unknown>
   downloadUpdate(): Promise<unknown>
   quitAndInstall(isSilent: boolean, isForceRunAfter: boolean): void
-  setFeedURL(options: { provider: string; url: string }): void
+  setFeedURL(options: Record<string, unknown>): void
 }
+
+/** Default GitHub publish config — mirrors electron-builder.yml */
+const GITHUB_FEED = { provider: 'github', owner: 'dever-labs', repo: 'postly' }
 
 let win: BrowserWindow | null = null
 let _autoUpdater: AutoUpdater | null = null
 
 function getAutoUpdater(): AutoUpdater {
   if (_autoUpdater) return _autoUpdater
-  // Lazy import — electron-updater is only loaded in packaged builds to avoid
-  // cross-platform binary issues during development.
+  // Lazy import — only in packaged builds to avoid cross-platform binary issues
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   return (require('electron-updater') as { autoUpdater: AutoUpdater }).autoUpdater
 }
@@ -37,10 +47,47 @@ function emit(event: UpdaterEvent) {
   }
 }
 
-export function initUpdater(mainWindow: BrowserWindow): void {
-  // Always store win so we can emit events in dev mode too
-  win = mainWindow
+/**
+ * Reads an optional enterprise.json from the app's resources directory.
+ * This file is bundled by IT at deployment time and takes precedence over
+ * the user-level update feed URL setting.
+ *
+ * Format: { "updateUrl": "https://updates.internal.corp/postly/" }
+ */
+export function getEnterpriseConfig(): EnterpriseConfig {
+  try {
+    // process.resourcesPath is only available in a packaged Electron app
+    const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
+    if (!resourcesPath) return {}
+    const configPath = path.join(resourcesPath, 'enterprise.json')
+    if (!fs.existsSync(configPath)) return {}
+    const raw = fs.readFileSync(configPath, 'utf-8')
+    return JSON.parse(raw) as EnterpriseConfig
+  } catch {
+    return {}
+  }
+}
 
+/**
+ * Switch the autoUpdater to the appropriate provider:
+ * - enterprise/user URL set → generic provider (internal mirror)
+ * - no URL → revert to GitHub Releases (default product channel)
+ *
+ * The two channels are completely isolated — enterprise mirrors never
+ * interfere with the standard GitHub release flow.
+ */
+export function applyFeedUrl(feedUrl: string | undefined): void {
+  if (!app.isPackaged) return
+  const au = getAutoUpdater()
+  if (feedUrl) {
+    au.setFeedURL({ provider: 'generic', url: feedUrl })
+  } else {
+    au.setFeedURL(GITHUB_FEED)
+  }
+}
+
+export function initUpdater(mainWindow: BrowserWindow): void {
+  win = mainWindow
   if (!app.isPackaged) return
 
   const au = getAutoUpdater()
@@ -58,7 +105,6 @@ export function initUpdater(mainWindow: BrowserWindow): void {
 
 export function checkForUpdates(): void {
   if (!app.isPackaged) {
-    // In dev mode give the user visible feedback rather than silently no-op
     emit({ type: 'checking' })
     setTimeout(() => emit({ type: 'not-available' }), 800)
     return
@@ -76,9 +122,10 @@ export function installUpdate(): void {
   getAutoUpdater().quitAndInstall(false, true)
 }
 
+/** @deprecated Use applyFeedUrl() directly. Kept for IPC back-compat. */
 export function setUpdateFeedUrl(feedUrl: string): void {
   if (!app.isPackaged) return
-  getAutoUpdater().setFeedURL({ provider: 'generic', url: feedUrl })
+  applyFeedUrl(feedUrl || undefined)
 }
 
 /** Inject a mock autoUpdater — for unit tests only. */

--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -9,7 +9,27 @@ export interface UpdaterEvent {
   error?: string
 }
 
+type AutoUpdater = {
+  autoDownload: boolean
+  autoInstallOnAppQuit: boolean
+  logger: unknown
+  on(event: string, handler: (...args: unknown[]) => void): void
+  checkForUpdates(): Promise<unknown>
+  downloadUpdate(): Promise<unknown>
+  quitAndInstall(isSilent: boolean, isForceRunAfter: boolean): void
+  setFeedURL(options: { provider: string; url: string }): void
+}
+
 let win: BrowserWindow | null = null
+let _autoUpdater: AutoUpdater | null = null
+
+function getAutoUpdater(): AutoUpdater {
+  if (_autoUpdater) return _autoUpdater
+  // Lazy import — electron-updater is only loaded in packaged builds to avoid
+  // cross-platform binary issues during development.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return (require('electron-updater') as { autoUpdater: AutoUpdater }).autoUpdater
+}
 
 function emit(event: UpdaterEvent) {
   if (win && !win.isDestroyed()) {
@@ -23,20 +43,17 @@ export function initUpdater(mainWindow: BrowserWindow): void {
 
   if (!app.isPackaged) return
 
-  // Lazy import — electron-updater is only loaded in packaged builds to avoid
-  // cross-platform binary issues during development.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
-  autoUpdater.autoDownload = false
-  autoUpdater.autoInstallOnAppQuit = true
-  autoUpdater.logger = null
+  const au = getAutoUpdater()
+  au.autoDownload = false
+  au.autoInstallOnAppQuit = true
+  au.logger = null
 
-  autoUpdater.on('checking-for-update', () => emit({ type: 'checking' }))
-  autoUpdater.on('update-available', (info: { version?: string }) => emit({ type: 'available', version: info.version }))
-  autoUpdater.on('update-not-available', () => emit({ type: 'not-available' }))
-  autoUpdater.on('download-progress', (progress: { percent: number }) => emit({ type: 'progress', percent: Math.round(progress.percent) }))
-  autoUpdater.on('update-downloaded', (info: { version?: string }) => emit({ type: 'downloaded', version: info.version }))
-  autoUpdater.on('error', (err: Error) => emit({ type: 'error', error: err.message }))
+  au.on('checking-for-update', () => emit({ type: 'checking' }))
+  au.on('update-available', (info: unknown) => emit({ type: 'available', version: (info as { version?: string }).version }))
+  au.on('update-not-available', () => emit({ type: 'not-available' }))
+  au.on('download-progress', (progress: unknown) => emit({ type: 'progress', percent: Math.round((progress as { percent: number }).percent) }))
+  au.on('update-downloaded', (info: unknown) => emit({ type: 'downloaded', version: (info as { version?: string }).version }))
+  au.on('error', (err: unknown) => emit({ type: 'error', error: (err as Error).message }))
 }
 
 export function checkForUpdates(): void {
@@ -46,28 +63,25 @@ export function checkForUpdates(): void {
     setTimeout(() => emit({ type: 'not-available' }), 800)
     return
   }
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
-  autoUpdater.checkForUpdates().catch(() => { /* handled via error event */ })
+  getAutoUpdater().checkForUpdates().catch(() => { /* handled via error event */ })
 }
 
 export function downloadUpdate(): void {
   if (!app.isPackaged) return
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
-  autoUpdater.downloadUpdate().catch(() => { /* handled via error event */ })
+  getAutoUpdater().downloadUpdate().catch(() => { /* handled via error event */ })
 }
 
 export function installUpdate(): void {
   if (!app.isPackaged) return
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
-  autoUpdater.quitAndInstall(false, true)
+  getAutoUpdater().quitAndInstall(false, true)
 }
 
 export function setUpdateFeedUrl(feedUrl: string): void {
   if (!app.isPackaged) return
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
-  autoUpdater.setFeedURL({ provider: 'generic', url: feedUrl })
+  getAutoUpdater().setFeedURL({ provider: 'generic', url: feedUrl })
+}
+
+/** Inject a mock autoUpdater — for unit tests only. */
+export function __setAutoUpdaterForTesting(au: AutoUpdater | null): void {
+  _autoUpdater = au
 }

--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -1,0 +1,68 @@
+import { app, BrowserWindow } from 'electron'
+import { autoUpdater } from 'electron-updater'
+
+export type UpdaterEventType = 'checking' | 'available' | 'not-available' | 'progress' | 'downloaded' | 'error'
+
+export interface UpdaterEvent {
+  type: UpdaterEventType
+  version?: string
+  percent?: number
+  error?: string
+}
+
+let win: BrowserWindow | null = null
+
+function emit(event: UpdaterEvent) {
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('postly:updater:event', event)
+  }
+}
+
+export function initUpdater(mainWindow: BrowserWindow): void {
+  win = mainWindow
+  autoUpdater.autoDownload = false
+  autoUpdater.autoInstallOnAppQuit = true
+  // Suppress electron-updater's own logger to avoid cluttering the console
+  autoUpdater.logger = null
+
+  autoUpdater.on('checking-for-update', () => {
+    emit({ type: 'checking' })
+  })
+
+  autoUpdater.on('update-available', (info) => {
+    emit({ type: 'available', version: (info as { version?: string }).version })
+  })
+
+  autoUpdater.on('update-not-available', () => {
+    emit({ type: 'not-available' })
+  })
+
+  autoUpdater.on('download-progress', (progress: { percent: number }) => {
+    emit({ type: 'progress', percent: Math.round(progress.percent) })
+  })
+
+  autoUpdater.on('update-downloaded', (info) => {
+    emit({ type: 'downloaded', version: (info as { version?: string }).version })
+  })
+
+  autoUpdater.on('error', (err: Error) => {
+    emit({ type: 'error', error: err.message })
+  })
+}
+
+export function checkForUpdates(): void {
+  if (!app.isPackaged) return
+  autoUpdater.checkForUpdates().catch(() => { /* handled via error event */ })
+}
+
+export function downloadUpdate(): void {
+  autoUpdater.downloadUpdate().catch(() => { /* handled via error event */ })
+}
+
+export function installUpdate(): void {
+  autoUpdater.quitAndInstall(false, true)
+}
+
+export function setUpdateFeedUrl(feedUrl: string): void {
+  autoUpdater.setFeedURL({ provider: 'generic', url: feedUrl })
+}

--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -1,5 +1,4 @@
 import { app, BrowserWindow } from 'electron'
-import { autoUpdater } from 'electron-updater'
 
 export type UpdaterEventType = 'checking' | 'available' | 'not-available' | 'progress' | 'downloaded' | 'error'
 
@@ -19,50 +18,56 @@ function emit(event: UpdaterEvent) {
 }
 
 export function initUpdater(mainWindow: BrowserWindow): void {
+  // Always store win so we can emit events in dev mode too
   win = mainWindow
+
+  if (!app.isPackaged) return
+
+  // Lazy import — electron-updater is only loaded in packaged builds to avoid
+  // cross-platform binary issues during development.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
   autoUpdater.autoDownload = false
   autoUpdater.autoInstallOnAppQuit = true
-  // Suppress electron-updater's own logger to avoid cluttering the console
   autoUpdater.logger = null
 
-  autoUpdater.on('checking-for-update', () => {
-    emit({ type: 'checking' })
-  })
-
-  autoUpdater.on('update-available', (info) => {
-    emit({ type: 'available', version: (info as { version?: string }).version })
-  })
-
-  autoUpdater.on('update-not-available', () => {
-    emit({ type: 'not-available' })
-  })
-
-  autoUpdater.on('download-progress', (progress: { percent: number }) => {
-    emit({ type: 'progress', percent: Math.round(progress.percent) })
-  })
-
-  autoUpdater.on('update-downloaded', (info) => {
-    emit({ type: 'downloaded', version: (info as { version?: string }).version })
-  })
-
-  autoUpdater.on('error', (err: Error) => {
-    emit({ type: 'error', error: err.message })
-  })
+  autoUpdater.on('checking-for-update', () => emit({ type: 'checking' }))
+  autoUpdater.on('update-available', (info: { version?: string }) => emit({ type: 'available', version: info.version }))
+  autoUpdater.on('update-not-available', () => emit({ type: 'not-available' }))
+  autoUpdater.on('download-progress', (progress: { percent: number }) => emit({ type: 'progress', percent: Math.round(progress.percent) }))
+  autoUpdater.on('update-downloaded', (info: { version?: string }) => emit({ type: 'downloaded', version: info.version }))
+  autoUpdater.on('error', (err: Error) => emit({ type: 'error', error: err.message }))
 }
 
 export function checkForUpdates(): void {
-  if (!app.isPackaged) return
+  if (!app.isPackaged) {
+    // In dev mode give the user visible feedback rather than silently no-op
+    emit({ type: 'checking' })
+    setTimeout(() => emit({ type: 'not-available' }), 800)
+    return
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
   autoUpdater.checkForUpdates().catch(() => { /* handled via error event */ })
 }
 
 export function downloadUpdate(): void {
+  if (!app.isPackaged) return
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
   autoUpdater.downloadUpdate().catch(() => { /* handled via error event */ })
 }
 
 export function installUpdate(): void {
+  if (!app.isPackaged) return
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
   autoUpdater.quitAndInstall(false, true)
 }
 
 export function setUpdateFeedUrl(feedUrl: string): void {
+  if (!app.isPackaged) return
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { autoUpdater } = require('electron-updater') as typeof import('electron-updater')
   autoUpdater.setFeedURL({ provider: 'generic', url: feedUrl })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -178,6 +178,7 @@ const api = {
     download: () => ipcRenderer.invoke('postly:updater:download'),
     install: () => ipcRenderer.invoke('postly:updater:install'),
     setFeed: (data: { url: string }) => ipcRenderer.invoke('postly:updater:set-feed', data),
+    getEnterpriseConfig: () => ipcRenderer.invoke('postly:updater:get-enterprise-config') as Promise<{ data?: { updateUrl?: string }; error?: string }>,
     onEvent: (cb: (event: { type: string; version?: string; percent?: number; error?: string }) => void) => {
       const handler = (_: unknown, event: unknown) => cb(event as { type: string; version?: string; percent?: number; error?: string })
       ipcRenderer.on('postly:updater:event', handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -173,6 +173,17 @@ const api = {
     import: () => ipcRenderer.invoke('postly:import'),
     importCollections: (data: { collections: unknown[] }) => ipcRenderer.invoke('postly:import:collections', data),
   },
+  updater: {
+    check: () => ipcRenderer.invoke('postly:updater:check'),
+    download: () => ipcRenderer.invoke('postly:updater:download'),
+    install: () => ipcRenderer.invoke('postly:updater:install'),
+    setFeed: (data: { url: string }) => ipcRenderer.invoke('postly:updater:set-feed', data),
+    onEvent: (cb: (event: { type: string; version?: string; percent?: number; error?: string }) => void) => {
+      const handler = (_: unknown, event: unknown) => cb(event as { type: string; version?: string; percent?: number; error?: string })
+      ipcRenderer.on('postly:updater:event', handler)
+      return () => ipcRenderer.removeListener('postly:updater:event', handler)
+    },
+  },
   window: {
     setTheme: (theme: 'dark' | 'light') => ipcRenderer.invoke('postly:window:set-theme', theme),
     minimize: () => ipcRenderer.invoke('postly:window:minimize'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { GitCommitOverlay } from './components/git/GitCommitOverlay'
 import { DeleteCollectionOverlay } from './components/collections/DeleteCollectionOverlay'
 import { Toaster } from './components/ui/Toast'
 import { TooltipProvider } from './components/ui/Tooltip'
+import { UpdateNotification } from './components/update/UpdateNotification'
 import { useCollectionsStore } from './store/collections'
 import { useEnvironmentsStore } from './store/environments'
 
@@ -20,6 +21,7 @@ export default function App(): React.ReactElement {
   return (
     <TooltipProvider delayDuration={400}>
       <div data-testid="app-root" className="h-screen w-screen bg-th-bg text-th-text-primary flex flex-col overflow-hidden">
+        <UpdateNotification />
         <AppShell />
         <SettingsModal />
         <GitCommitOverlay />

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react'
 import { AppearanceSettings } from '@/components/settings/tabs/AppearanceSettings'
 import { GeneralSettings } from '@/components/settings/tabs/GeneralSettings'
 import { AiSettings } from '@/components/settings/tabs/AiSettings'
+import { UpdateSettings } from '@/components/settings/tabs/UpdateSettings'
 import { useUIStore } from '@/store/ui'
 import { cn } from '@/lib/utils'
 
@@ -10,6 +11,7 @@ const TABS = [
   { id: 'general', label: 'General' },
   { id: 'appearance', label: 'Appearance' },
   { id: 'ai', label: 'AI' },
+  { id: 'updates', label: 'Updates' },
 ]
 
 function TabContent({ tab }: { tab: string }) {
@@ -17,6 +19,7 @@ function TabContent({ tab }: { tab: string }) {
     case 'general': return <GeneralSettings />
     case 'appearance': return <AppearanceSettings />
     case 'ai': return <AiSettings />
+    case 'updates': return <UpdateSettings />
     default: return null
   }
 }

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -7,10 +7,12 @@ const DEFAULTS: GeneralSettings = {
   defaultTimeout: 30000,
   followRedirects: true,
   sslVerification: true,
+  autoUpdate: true,
 }
 
 export function GeneralSettings() {
   const [settings, setSettings] = useState<GeneralSettings>(DEFAULTS)
+  const [updateStatus, setUpdateStatus] = useState<string>('')
 
   useEffect(() => {
     ;window.api.settings.get({ key: 'general' }).then(({ data }: { data: GeneralSettings }) => {
@@ -18,10 +20,26 @@ export function GeneralSettings() {
     })
   }, [])
 
+  useEffect(() => {
+    const off = window.api.updater.onEvent((event) => {
+      if (event.type === 'checking') setUpdateStatus('Checking for updates…')
+      else if (event.type === 'available') setUpdateStatus(`Update ${event.version} available — downloading from the notification bar`)
+      else if (event.type === 'not-available') setUpdateStatus('You are on the latest version.')
+      else if (event.type === 'error') setUpdateStatus(`Error: ${event.error}`)
+      else if (event.type === 'downloaded') setUpdateStatus(`Update ${event.version} downloaded — restart to install`)
+    })
+    return () => { off() }
+  }, [])
+
   const update = <K extends keyof GeneralSettings>(key: K, value: GeneralSettings[K]) => {
     const next = { ...settings, [key]: value }
     setSettings(next)
     ;window.api.settings.set({ key: 'general', value: next })
+  }
+
+  const handleCheckNow = () => {
+    setUpdateStatus('')
+    window.api.updater.check()
   }
 
   return (
@@ -59,6 +77,45 @@ export function GeneralSettings() {
             />
             <span className="text-sm text-th-text-secondary">Follow Redirects</span>
           </label>
+        </div>
+      </div>
+
+      <div className="border-t border-th-border pt-4 flex flex-col gap-4">
+        <h4 className="text-xs font-semibold text-th-text-muted uppercase tracking-wide">Updates</h4>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={settings.autoUpdate ?? true}
+            onChange={(e) => update('autoUpdate', e.target.checked)}
+            className="h-4 w-4 accent-blue-500"
+          />
+          <span className="text-sm text-th-text-secondary">Check for updates on startup</span>
+        </label>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-th-text-muted">
+            Custom update feed URL <span className="opacity-60">(optional — for enterprise/self-hosted)</span>
+          </label>
+          <Input
+            type="url"
+            className="w-full max-w-sm"
+            placeholder="https://updates.example.com/postly/"
+            value={settings.updateFeedUrl ?? ''}
+            onChange={(e) => update('updateFeedUrl', e.target.value || undefined)}
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleCheckNow}
+            className="rounded-sm border border-th-border bg-th-surface-raised px-3 py-1.5 text-xs text-th-text-secondary hover:text-th-text-primary hover:border-th-border-active transition-colors focus:outline-hidden"
+          >
+            Check for updates now
+          </button>
+          {updateStatus && (
+            <span className="text-xs text-th-text-muted">{updateStatus}</span>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/GeneralSettings.tsx
@@ -12,7 +12,6 @@ const DEFAULTS: GeneralSettings = {
 
 export function GeneralSettings() {
   const [settings, setSettings] = useState<GeneralSettings>(DEFAULTS)
-  const [updateStatus, setUpdateStatus] = useState<string>('')
 
   useEffect(() => {
     ;window.api.settings.get({ key: 'general' }).then(({ data }: { data: GeneralSettings }) => {
@@ -20,26 +19,10 @@ export function GeneralSettings() {
     })
   }, [])
 
-  useEffect(() => {
-    const off = window.api.updater.onEvent((event) => {
-      if (event.type === 'checking') setUpdateStatus('Checking for updates…')
-      else if (event.type === 'available') setUpdateStatus(`Update ${event.version} available — downloading from the notification bar`)
-      else if (event.type === 'not-available') setUpdateStatus('You are on the latest version.')
-      else if (event.type === 'error') setUpdateStatus(`Error: ${event.error}`)
-      else if (event.type === 'downloaded') setUpdateStatus(`Update ${event.version} downloaded — restart to install`)
-    })
-    return () => { off() }
-  }, [])
-
   const update = <K extends keyof GeneralSettings>(key: K, value: GeneralSettings[K]) => {
     const next = { ...settings, [key]: value }
     setSettings(next)
     ;window.api.settings.set({ key: 'general', value: next })
-  }
-
-  const handleCheckNow = () => {
-    setUpdateStatus('')
-    window.api.updater.check()
   }
 
   return (
@@ -77,45 +60,6 @@ export function GeneralSettings() {
             />
             <span className="text-sm text-th-text-secondary">Follow Redirects</span>
           </label>
-        </div>
-      </div>
-
-      <div className="border-t border-th-border pt-4 flex flex-col gap-4">
-        <h4 className="text-xs font-semibold text-th-text-muted uppercase tracking-wide">Updates</h4>
-
-        <label className="flex items-center gap-3 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={settings.autoUpdate ?? true}
-            onChange={(e) => update('autoUpdate', e.target.checked)}
-            className="h-4 w-4 accent-blue-500"
-          />
-          <span className="text-sm text-th-text-secondary">Check for updates on startup</span>
-        </label>
-
-        <div>
-          <label className="mb-1.5 block text-xs font-medium text-th-text-muted">
-            Custom update feed URL <span className="opacity-60">(optional — for enterprise/self-hosted)</span>
-          </label>
-          <Input
-            type="url"
-            className="w-full max-w-sm"
-            placeholder="https://updates.example.com/postly/"
-            value={settings.updateFeedUrl ?? ''}
-            onChange={(e) => update('updateFeedUrl', e.target.value || undefined)}
-          />
-        </div>
-
-        <div className="flex items-center gap-3">
-          <button
-            onClick={handleCheckNow}
-            className="rounded-sm border border-th-border bg-th-surface-raised px-3 py-1.5 text-xs text-th-text-secondary hover:text-th-text-primary hover:border-th-border-active transition-colors focus:outline-hidden"
-          >
-            Check for updates now
-          </button>
-          {updateStatus && (
-            <span className="text-xs text-th-text-muted">{updateStatus}</span>
-          )}
         </div>
       </div>
     </div>

--- a/src/renderer/src/components/settings/tabs/UpdateSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/UpdateSettings.tsx
@@ -10,10 +10,14 @@ const DEFAULTS: Pick<GeneralSettings, 'autoUpdate' | 'updateFeedUrl'> = {
 export function UpdateSettings() {
   const [settings, setSettings] = useState(DEFAULTS)
   const [updateStatus, setUpdateStatus] = useState<string>('')
+  const [enterpriseUrl, setEnterpriseUrl] = useState<string | null>(null)
 
   useEffect(() => {
     window.api.settings.get({ key: 'general' }).then(({ data }: { data: GeneralSettings }) => {
       if (data) setSettings({ autoUpdate: data.autoUpdate ?? true, updateFeedUrl: data.updateFeedUrl })
+    })
+    window.api.updater.getEnterpriseConfig().then(({ data }) => {
+      setEnterpriseUrl(data?.updateUrl ?? null)
     })
   }, [])
 
@@ -33,6 +37,7 @@ export function UpdateSettings() {
     setSettings(next)
     window.api.settings.get({ key: 'general' }).then(({ data }: { data: GeneralSettings }) => {
       window.api.settings.set({ key: 'general', value: { ...data, ...next } })
+      window.api.updater.setFeed({ url: (next.updateFeedUrl ?? '') })
     })
   }
 
@@ -40,6 +45,8 @@ export function UpdateSettings() {
     setUpdateStatus('')
     window.api.updater.check()
   }
+
+  const isEnterpriseManaged = Boolean(enterpriseUrl)
 
   return (
     <div className="flex flex-col gap-5">
@@ -59,23 +66,6 @@ export function UpdateSettings() {
           </div>
         </label>
 
-        <div>
-          <label className="mb-1.5 block text-xs font-medium text-th-text-muted">
-            Custom update feed URL
-            <span className="ml-1.5 opacity-60">(optional — for enterprise or self-hosted)</span>
-          </label>
-          <Input
-            type="url"
-            className="w-full max-w-sm"
-            placeholder="https://updates.example.com/postly/"
-            value={settings.updateFeedUrl ?? ''}
-            onChange={(e) => update('updateFeedUrl', e.target.value || undefined)}
-          />
-          <p className="mt-1.5 text-xs text-th-text-muted">
-            Leave blank to use the default GitHub releases feed.
-          </p>
-        </div>
-
         <div className="flex items-center gap-3 pt-1">
           <button
             onClick={handleCheckNow}
@@ -87,6 +77,49 @@ export function UpdateSettings() {
             <span className="text-xs text-th-text-muted">{updateStatus}</span>
           )}
         </div>
+      </div>
+
+      {/* ── Enterprise / Disconnected Mode ─────────────────────────────── */}
+      <div className="border-t border-th-border pt-4 flex flex-col gap-3">
+        <div>
+          <h4 className="text-xs font-semibold text-th-text-muted uppercase tracking-wide">
+            Enterprise / Disconnected Mode
+          </h4>
+          <p className="mt-1 text-xs text-th-text-muted leading-relaxed">
+            Configure an internal update mirror for air-gapped or proxy-restricted networks.
+            When set, updates are fetched from this server instead of GitHub Releases.{' '}
+            <span className="opacity-70">
+              The server must serve <code className="font-mono">latest.yml</code> and the installer
+              binaries in the standard electron-updater generic provider format.
+            </span>
+          </p>
+        </div>
+
+        {isEnterpriseManaged ? (
+          <div className="rounded-sm border border-blue-500/30 bg-blue-500/5 px-3 py-2.5 flex flex-col gap-1">
+            <span className="text-xs font-medium text-blue-400">Managed by your administrator</span>
+            <span className="text-xs text-th-text-muted font-mono break-all">{enterpriseUrl}</span>
+            <span className="text-xs text-th-text-muted opacity-70 mt-0.5">
+              This URL is configured in the bundled enterprise.json and cannot be changed here.
+            </span>
+          </div>
+        ) : (
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-th-text-muted">
+              Internal update server URL
+            </label>
+            <Input
+              type="url"
+              className="w-full max-w-sm"
+              placeholder="https://updates.internal.corp/postly/"
+              value={settings.updateFeedUrl ?? ''}
+              onChange={(e) => update('updateFeedUrl', e.target.value || undefined)}
+            />
+            <p className="mt-1.5 text-xs text-th-text-muted">
+              Leave blank to use the default GitHub Releases channel.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/settings/tabs/UpdateSettings.tsx
+++ b/src/renderer/src/components/settings/tabs/UpdateSettings.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react'
+import type { GeneralSettings } from '@/types'
+import { Input } from '@/components/ui/Input'
+
+const DEFAULTS: Pick<GeneralSettings, 'autoUpdate' | 'updateFeedUrl'> = {
+  autoUpdate: true,
+  updateFeedUrl: undefined,
+}
+
+export function UpdateSettings() {
+  const [settings, setSettings] = useState(DEFAULTS)
+  const [updateStatus, setUpdateStatus] = useState<string>('')
+
+  useEffect(() => {
+    window.api.settings.get({ key: 'general' }).then(({ data }: { data: GeneralSettings }) => {
+      if (data) setSettings({ autoUpdate: data.autoUpdate ?? true, updateFeedUrl: data.updateFeedUrl })
+    })
+  }, [])
+
+  useEffect(() => {
+    const off = window.api.updater.onEvent((event) => {
+      if (event.type === 'checking') setUpdateStatus('Checking for updates…')
+      else if (event.type === 'available') setUpdateStatus(`Update ${event.version} is available — see the notification bar to download.`)
+      else if (event.type === 'not-available') setUpdateStatus('You are on the latest version.')
+      else if (event.type === 'error') setUpdateStatus(`Error: ${event.error}`)
+      else if (event.type === 'downloaded') setUpdateStatus(`Update ${event.version} downloaded — restart to install.`)
+    })
+    return () => { off() }
+  }, [])
+
+  const update = (key: 'autoUpdate' | 'updateFeedUrl', value: boolean | string | undefined) => {
+    const next = { ...settings, [key]: value }
+    setSettings(next)
+    window.api.settings.get({ key: 'general' }).then(({ data }: { data: GeneralSettings }) => {
+      window.api.settings.set({ key: 'general', value: { ...data, ...next } })
+    })
+  }
+
+  const handleCheckNow = () => {
+    setUpdateStatus('')
+    window.api.updater.check()
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <h3 className="text-sm font-semibold text-th-text-primary">Updates</h3>
+
+      <div className="flex flex-col gap-4">
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={settings.autoUpdate ?? true}
+            onChange={(e) => update('autoUpdate', e.target.checked)}
+            className="h-4 w-4 accent-blue-500"
+          />
+          <div>
+            <span className="text-sm text-th-text-secondary">Check for updates on startup</span>
+            <p className="text-xs text-th-text-muted mt-0.5">Automatically checks for new releases when Postly opens.</p>
+          </div>
+        </label>
+
+        <div>
+          <label className="mb-1.5 block text-xs font-medium text-th-text-muted">
+            Custom update feed URL
+            <span className="ml-1.5 opacity-60">(optional — for enterprise or self-hosted)</span>
+          </label>
+          <Input
+            type="url"
+            className="w-full max-w-sm"
+            placeholder="https://updates.example.com/postly/"
+            value={settings.updateFeedUrl ?? ''}
+            onChange={(e) => update('updateFeedUrl', e.target.value || undefined)}
+          />
+          <p className="mt-1.5 text-xs text-th-text-muted">
+            Leave blank to use the default GitHub releases feed.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3 pt-1">
+          <button
+            onClick={handleCheckNow}
+            className="rounded-sm border border-th-border bg-th-surface-raised px-3 py-1.5 text-xs text-th-text-secondary hover:text-th-text-primary hover:border-th-border-active transition-colors focus:outline-hidden"
+          >
+            Check for updates now
+          </button>
+          {updateStatus && (
+            <span className="text-xs text-th-text-muted">{updateStatus}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/update/UpdateNotification.tsx
+++ b/src/renderer/src/components/update/UpdateNotification.tsx
@@ -1,0 +1,114 @@
+import { Download, RefreshCw, X } from 'lucide-react'
+import React, { useEffect, useState } from 'react'
+
+type UpdateState =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'available'; version: string }
+  | { status: 'downloading'; percent: number }
+  | { status: 'downloaded'; version: string }
+  | { status: 'error'; message: string }
+
+export function UpdateNotification() {
+  const [state, setState] = useState<UpdateState>({ status: 'idle' })
+
+  useEffect(() => {
+    const off = window.api.updater.onEvent((event) => {
+      if (event.type === 'checking') {
+        setState({ status: 'checking' })
+      } else if (event.type === 'available') {
+        setState({ status: 'available', version: event.version ?? '' })
+      } else if (event.type === 'not-available') {
+        setState({ status: 'idle' })
+      } else if (event.type === 'progress') {
+        setState({ status: 'downloading', percent: event.percent ?? 0 })
+      } else if (event.type === 'downloaded') {
+        setState({ status: 'downloaded', version: event.version ?? '' })
+      } else if (event.type === 'error') {
+        setState({ status: 'error', message: event.error ?? 'Unknown error' })
+      }
+    })
+    return () => { off() }
+  }, [])
+
+  if (state.status === 'idle' || state.status === 'checking') return null
+
+  const dismiss = () => setState({ status: 'idle' })
+
+  if (state.status === 'available') {
+    return (
+      <Banner color="blue" onDismiss={dismiss}>
+        <span>Update <strong>{state.version}</strong> is available.</span>
+        <BannerButton onClick={() => window.api.updater.download()} icon={<Download className="h-3.5 w-3.5" />}>
+          Download
+        </BannerButton>
+      </Banner>
+    )
+  }
+
+  if (state.status === 'downloading') {
+    return (
+      <Banner color="blue">
+        <span>Downloading update… {state.percent}%</span>
+        <div className="h-1.5 w-32 rounded-full bg-blue-900 overflow-hidden">
+          <div className="h-full rounded-full bg-blue-400 transition-all" style={{ width: `${state.percent}%` }} />
+        </div>
+      </Banner>
+    )
+  }
+
+  if (state.status === 'downloaded') {
+    return (
+      <Banner color="green" onDismiss={dismiss}>
+        <span>Update <strong>{state.version}</strong> ready to install.</span>
+        <BannerButton onClick={() => window.api.updater.install()} icon={<RefreshCw className="h-3.5 w-3.5" />}>
+          Restart &amp; Install
+        </BannerButton>
+      </Banner>
+    )
+  }
+
+  if (state.status === 'error') {
+    return (
+      <Banner color="red" onDismiss={dismiss}>
+        <span>Update check failed: {state.message}</span>
+      </Banner>
+    )
+  }
+
+  return null
+}
+
+function Banner({
+  children,
+  color,
+  onDismiss,
+}: {
+  children: React.ReactNode
+  color: 'blue' | 'green' | 'red'
+  onDismiss?: () => void
+}) {
+  const bg = { blue: 'bg-blue-950 border-blue-800 text-blue-200', green: 'bg-emerald-950 border-emerald-800 text-emerald-200', red: 'bg-rose-950 border-rose-800 text-rose-200' }[color]
+  return (
+    <div className={`flex items-center justify-between gap-3 border-b px-4 py-1.5 text-xs ${bg}`}>
+      <div className="flex items-center gap-3 flex-1">{children}</div>
+      {onDismiss && (
+        <button onClick={onDismiss} className="shrink-0 opacity-60 hover:opacity-100 focus:outline-hidden">
+          <X className="h-3.5 w-3.5" />
+        </button>
+      )}
+    </div>
+  )
+}
+
+function BannerButton({ children, onClick, icon }: { children: React.ReactNode; onClick: () => void; icon?: React.ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      className="flex items-center gap-1.5 rounded-sm border border-current/30 px-2.5 py-0.5 font-medium opacity-90 hover:opacity-100 focus:outline-hidden"
+    >
+      {icon}
+      {children}
+    </button>
+  )
+}

--- a/src/renderer/src/store/settings.ts
+++ b/src/renderer/src/store/settings.ts
@@ -23,6 +23,7 @@ const DEFAULT_GENERAL: GeneralSettings = {
   defaultTimeout: 30000,
   followRedirects: true,
   sslVerification: true,
+  autoUpdate: true,
 }
 const DEFAULT_BACKSTAGE: BackstageSettings = { baseUrl: '', token: '', autoSync: false, authProvider: 'token' }
 const DEFAULT_GITHUB: GitHubSettings = { baseUrl: 'https://github.com', clientId: '', clientSecret: '', token: '', repo: '', orgs: [] }

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -192,6 +192,8 @@ export interface GeneralSettings {
   defaultTimeout: number
   followRedirects: boolean
   sslVerification: boolean
+  autoUpdate: boolean
+  updateFeedUrl?: string
 }
 
 export interface AiSettings {


### PR DESCRIPTION
Closes #89

## Summary

Adds automatic update support via `electron-updater`, with a dedicated **Updates** settings tab and full enterprise/air-gapped deployment support.

## What's included

### Auto-update core
- `src/main/services/updater.ts` — updater service with lazy-require (packaged builds only), event forwarding to renderer, and `__setAutoUpdaterForTesting` injection seam
- `src/main/ipc/updater.ts` — IPC handlers for check / download / install / set-feed / get-enterprise-config
- `src/preload/index.ts` — `window.api.updater` bridge
- `src/renderer/src/components/update/UpdateNotification.tsx` — persistent banner (checking → available → downloading → downloaded states)

### Settings UI
- New **Updates** tab in Settings modal (extracted from General)
- Auto-update on startup toggle
- Manual "Check for updates now" button with inline status feedback (works in dev mode too)

### Enterprise / disconnected-mode
- `getEnterpriseConfig()` reads `resources/enterprise.json` bundled by IT at deploy time — no per-user configuration needed
- `applyFeedUrl()` switches between GitHub provider (default) and `generic` provider (internal mirror); clearing the URL reverts to GitHub
- IPC `set-feed` respects enterprise lock — user cannot override bundled config
- UI shows "Managed by your administrator" notice when enterprise config is active

**IT deployment:** bundle `resources/enterprise.json`:
```json
{ "updateUrl": "https://updates.internal.corp/postly/" }
```
The internal server just needs to serve `latest-mac.yml` / `latest.yml` + installers in the standard electron-updater generic provider format. IT controls the manifest, so rollback is just updating the version in that file.

### Tests
- 41 unit tests: service (dev mode, packaged mode, event forwarding, provider switching) + IPC handlers (all channels, enterprise lock, error paths) + `getEnterpriseConfig` (file parsing, missing file, malformed JSON)

## Two isolated update channels

| | Normal users | Enterprise |
|---|---|---|
| Provider | GitHub Releases | `generic` (internal mirror) |
| Version control | Latest release only | IT controls `latest.yml` |
| Rollback | Not supported | ✅ IT updates manifest |
| Offline support | ❌ | ✅ Air-gapped network |