### PR TITLE
fix: install Copilot CLI and Claude Code in devcontainer init

### DIFF
--- a/.devcontainer/init.sh
+++ b/.devcontainer/init.sh
@@ -1,5 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "==> Installing npm dependencies..."
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${CYAN}==> Installing Copilot CLI and Claude Code...${NC}"
+npm install -g @github/copilot @anthropic-ai/claude-code
+sudo ln -sf "$(npm prefix -g)/bin/copilot" /usr/local/bin/copilot
+sudo ln -sf "$(npm prefix -g)/bin/claude" /usr/local/bin/claude
+
+echo -e "${CYAN}==> Installing npm dependencies...${NC}"
 npm install
+
+echo -e ""
+echo -e "${GREEN}✔ Devcontainer ready!${NC}"
+echo -e ""
+echo -e "Quick-start commands:"
+echo -e "  ${YELLOW}npm run dev${NC}    — start the app in development mode"
+echo -e "  ${YELLOW}npm test${NC}       — run tests"
+echo -e ""
+
+if ls ~/.copilot/*.json &>/dev/null 2>&1; then
+  echo -e "${GREEN}✔ GitHub Copilot CLI authenticated.${NC}"
+else
+  echo -e "Run ${YELLOW}copilot auth login${NC} to authenticate GitHub Copilot CLI."
+  echo -e "Credentials persist in a Docker volume — no re-login needed after rebuild."
+fi


### PR DESCRIPTION
## Problem
When a service repo defines its own `postCreateCommand` (like `bash .devcontainer/init.sh`), it overrides the `frontend-dev` image's embedded metadata lifecycle script — so `@github/copilot` and `@anthropic-ai/claude-code` were never installed. The `copilot` and `claude` commands were missing in the container.

## Fix
Install Copilot CLI and Claude Code at the top of `init.sh`, following the same pattern as `images/frontend-dev/init.sh` in the devcontainers repo. Also improves messaging with colors and a ready banner consistent with other dever-labs devcontainers.