### PR TITLE
chore(deps): bump electron from 41.8.0 to 42.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "@typescript-eslint/parser": "^8.61.1",
         "@vitejs/plugin-react": "^6.0.2",
         "autoprefixer": "^10.5.0",
-        "electron": "^41.8.0",
+        "electron": "^42.4.1",
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "eslint": "^10.5.0",
@@ -6362,11 +6362,10 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.8.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.8.0.tgz",
-      "integrity": "sha512-mQRqdFxB6/EAyA9pPn00EC1KFytTijOQO52zBvl9HypWBvvibC3P4iSrT4CSVVksolOPKZZm8U4Cfjb5IHxZVA==",
+      "version": "42.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.4.1.tgz",
+      "integrity": "sha512-8CYHJP5O4wFO+ycoJR98yy907MmPeo+vWXrzjxmGGgRNKqv8pOjjm+wphO0CCgQJnBU7+QUPSJS4QXhbKrO50w==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",
@@ -6374,7 +6373,8 @@
         "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
         "node": ">= 22.12.0"

--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "@typescript-eslint/parser": "^8.61.1",
     "@vitejs/plugin-react": "^6.0.2",
     "autoprefixer": "^10.5.0",
-    "electron": "^41.8.0",
+    "electron": "^42.4.1",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
     "eslint": "^10.5.0",


### PR DESCRIPTION
Upgrades Electron from 41.8.0 to 42.4.1 (major version bump).

**Verified:**
- ✅ 420/420 tests pass
- ✅ 0 TypeScript errors  
- ✅ 0 audit vulnerabilities
- ✅ Lint clean (3 pre-existing warnings, unchanged)

**Breaking change audit (v41 → v42):**

| Change | Impact on Postly |
|---|---|
| macOS `Notification` now requires code-signing | ✅ Not used |
| `ELECTRON_SKIP_BINARY_DOWNLOAD` env var removed | ✅ Not set in CI |
| `session.clearStorageData({ quotas })` removed | ✅ Not used |
| Protocol names validated (RFC 3986, no uppercase/underscores) | ✅ No custom protocols registered |
| `BrowserWindow` width/height clamped to min/max at creation | ✅ `1280×800` satisfies `minWidth: 900, minHeight: 600` |
| OSR default device scale factor changed to 1.0 | ✅ OSR not used |
| `webRequest` now fires for intercepted protocol URLs | ✅ No protocol interceptors |

Electron 42 ships with Chromium 148 and Node.js v24.16.0. No app code changes required.