### PR TITLE
feat(folders): infinite-depth folder tree — closes #100

### DIFF
--- a/e2e/import-export.spec.ts
+++ b/e2e/import-export.spec.ts
@@ -1,0 +1,200 @@
+// e2e/import-export.spec.ts
+// Tests import of both new (folders) and old (groups) export formats
+import type { Page } from '@playwright/test'
+import { test, expect } from './fixtures'
+
+function buildRequest(name: string, method: string, url: string) {
+  return {
+    name,
+    method,
+    url,
+    protocol: 'http',
+    params: [],
+    headers: [],
+    bodyType: 'none',
+    bodyContent: '',
+    auth: { type: 'none', config: {} },
+    ssl: 'inherit',
+    description: '',
+    protocolConfig: {},
+  }
+}
+
+async function ensureLocalSourceVisible(window: Page) {
+  const sourceContent = window.locator('[data-testid="source-content-local"]')
+  if (!(await sourceContent.isVisible())) {
+    await window.locator('[data-testid="source-toggle-local"]').click()
+  }
+  await expect(sourceContent).toBeVisible()
+}
+
+async function expandTreeItem(window: Page, label: string, childLabel: string) {
+  const sidebar = window.locator('[data-testid="sidebar"]')
+  const child = sidebar.getByText(childLabel, { exact: true }).first()
+  if (await child.isVisible()) return
+
+  const labelText = sidebar.getByText(label, { exact: true }).first()
+  await expect(labelText).toBeVisible()
+  await labelText.locator('xpath=ancestor::button[1]/preceding-sibling::button[1]').click()
+  await expect(child).toBeVisible()
+}
+
+async function importCollectionsAndReload(window: Page, collections: Array<Record<string, unknown>>) {
+  await window.evaluate(async (input: Array<Record<string, unknown>>) => {
+    const result = await window.api.exportImport.importCollections({ collections: input })
+    if ((result as { error?: string }).error) {
+      throw new Error((result as { error: string }).error)
+    }
+  }, collections)
+
+  await window.reload()
+  await window.waitForSelector('[data-testid="app-root"]', { timeout: 20_000 })
+  await ensureLocalSourceVisible(window)
+}
+
+async function getRootFolderIdByName(window: Page, name: string) {
+  return window.evaluate(async (collectionName: string) => {
+    const result = await window.api.folders.list()
+    const folders = ((result as { data?: Array<Record<string, unknown>> }).data ?? [])
+    const match = folders.find((folder) => !((folder.parentId ?? folder.parent_id) as string | null | undefined) && folder.name === collectionName)
+    return (match?.id as string | null | undefined) ?? null
+  }, name)
+}
+
+const timestamp = Date.now()
+const importedCollectionIds: string[] = []
+
+const newFormatCollectionName = `New Format API ${timestamp}`
+const rootLevelCollectionName = `Root Level API ${timestamp}`
+const legacyCollectionName = `Legacy API ${timestamp}`
+
+const endpointsFolderName = `Endpoints ${timestamp}`
+const newFormatRequestName = `Get Health ${timestamp}`
+const rootLevelRequestName = `Ping Root ${timestamp}`
+const legacyGroupName = `Users ${timestamp}`
+const legacyRequestName = `List Users ${timestamp}`
+
+test.afterAll(async ({ window }) => {
+  await window.evaluate(async (ids: string[]) => {
+    for (const id of ids) {
+      await window.api.folders.delete({ id })
+    }
+  }, importedCollectionIds)
+})
+
+test.describe('Import — new format (folders)', () => {
+  test.beforeAll(async ({ window }) => {
+    await importCollectionsAndReload(window, [
+      {
+        name: newFormatCollectionName,
+        description: '',
+        source: 'local',
+        auth: { type: 'none', config: {} },
+        ssl: 'inherit',
+        requests: [],
+        folders: [
+          {
+            name: endpointsFolderName,
+            description: '',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            requests: [buildRequest(newFormatRequestName, 'GET', '/health')],
+            folders: [],
+          },
+        ],
+      },
+    ])
+
+    const collectionId = await getRootFolderIdByName(window, newFormatCollectionName)
+    if (!collectionId) throw new Error(`Imported collection not found: ${newFormatCollectionName}`)
+    importedCollectionIds.push(collectionId)
+  })
+
+  test('shows the imported collection in the sidebar', async ({ window }) => {
+    await expect(window.locator('[data-testid="sidebar"]').getByText(newFormatCollectionName, { exact: true })).toBeVisible()
+  })
+
+  test('shows the sub-folder in the sidebar after expanding', async ({ window }) => {
+    await expandTreeItem(window, newFormatCollectionName, endpointsFolderName)
+    await expect(window.locator('[data-testid="sidebar"]').getByText(endpointsFolderName, { exact: true })).toBeVisible()
+  })
+
+  test('shows the request inside the sub-folder', async ({ window }) => {
+    await expandTreeItem(window, newFormatCollectionName, endpointsFolderName)
+    await expandTreeItem(window, endpointsFolderName, newFormatRequestName)
+    await expect(window.locator('[data-testid="sidebar"]').getByText(newFormatRequestName, { exact: true })).toBeVisible()
+  })
+})
+
+test.describe('Import — new format with root-level requests', () => {
+  test.beforeAll(async ({ window }) => {
+    await importCollectionsAndReload(window, [
+      {
+        name: rootLevelCollectionName,
+        description: '',
+        source: 'local',
+        auth: { type: 'none', config: {} },
+        ssl: 'inherit',
+        requests: [buildRequest(rootLevelRequestName, 'GET', '/ping')],
+        folders: [],
+      },
+    ])
+
+    const collectionId = await getRootFolderIdByName(window, rootLevelCollectionName)
+    if (!collectionId) throw new Error(`Imported collection not found: ${rootLevelCollectionName}`)
+    importedCollectionIds.push(collectionId)
+  })
+
+  test('shows the collection', async ({ window }) => {
+    await expect(window.locator('[data-testid="sidebar"]').getByText(rootLevelCollectionName, { exact: true })).toBeVisible()
+  })
+
+  test('shows the root-level request directly under the collection', async ({ window }) => {
+    await expandTreeItem(window, rootLevelCollectionName, rootLevelRequestName)
+    await expect(window.locator('[data-testid="sidebar"]').getByText(rootLevelRequestName, { exact: true })).toBeVisible()
+  })
+})
+
+test.describe('Import — old format (groups)', () => {
+  test.beforeAll(async ({ window }) => {
+    await importCollectionsAndReload(window, [
+      {
+        name: legacyCollectionName,
+        description: '',
+        source: 'local',
+        auth: { type: 'none', config: {} },
+        ssl: 'inherit',
+        requests: [],
+        groups: [
+          {
+            name: legacyGroupName,
+            description: '',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            requests: [buildRequest(legacyRequestName, 'GET', '/users')],
+            folders: [],
+          },
+        ],
+      },
+    ])
+
+    const collectionId = await getRootFolderIdByName(window, legacyCollectionName)
+    if (!collectionId) throw new Error(`Imported collection not found: ${legacyCollectionName}`)
+    importedCollectionIds.push(collectionId)
+  })
+
+  test('shows the legacy collection in the sidebar', async ({ window }) => {
+    await expect(window.locator('[data-testid="sidebar"]').getByText(legacyCollectionName, { exact: true })).toBeVisible()
+  })
+
+  test('shows the group as a folder after expanding', async ({ window }) => {
+    await expandTreeItem(window, legacyCollectionName, legacyGroupName)
+    await expect(window.locator('[data-testid="sidebar"]').getByText(legacyGroupName, { exact: true })).toBeVisible()
+  })
+
+  test('shows the request inside the group', async ({ window }) => {
+    await expandTreeItem(window, legacyCollectionName, legacyGroupName)
+    await expandTreeItem(window, legacyGroupName, legacyRequestName)
+    await expect(window.locator('[data-testid="sidebar"]').getByText(legacyRequestName, { exact: true })).toBeVisible()
+  })
+})

--- a/src/main/database/index.ts
+++ b/src/main/database/index.ts
@@ -26,12 +26,91 @@ export async function initDatabase(): Promise<void> {
   runMigrations()
   // is_dirty for local requests is an in-session editor flag — reset on startup.
   // Git-sourced requests keep is_dirty as "uncommitted to git" across restarts.
-  db.run(`UPDATE requests SET is_dirty = 0 WHERE group_id IN (
-    SELECT g.id FROM groups g
-    JOIN collections c ON c.id = g.collection_id
-    WHERE c.source NOT IN ('git', 'github', 'gitlab')
-  )`)
+  db.run(`
+    WITH RECURSIVE folder_root AS (
+      SELECT id, parent_id, id AS root_id FROM folders
+      UNION ALL
+      SELECT fr.id, parent.parent_id, parent.id AS root_id
+      FROM folder_root fr
+      JOIN folders parent ON parent.id = fr.parent_id
+    )
+    UPDATE requests
+    SET is_dirty = 0
+    WHERE folder_id IN (
+      SELECT DISTINCT fr.id
+      FROM folder_root fr
+      JOIN folders root ON root.id = fr.root_id
+      WHERE fr.parent_id IS NULL
+        AND root.source NOT IN ('git', 'github', 'gitlab')
+    )
+  `)
   persistDb()
+}
+
+function tableExists(table: string): boolean {
+  const result = db.exec(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = '${table.replace(/'/g, "''")}'`)
+  return (result[0]?.values.length ?? 0) > 0
+}
+
+function hasColumn(table: string, col: string): boolean {
+  if (!tableExists(table)) return false
+  const result = db.exec(`SELECT name FROM pragma_table_info('${table.replace(/'/g, "''")}') WHERE name = '${col.replace(/'/g, "''")}'`)
+  return (result[0]?.values.length ?? 0) > 0
+}
+
+function recreateDraftTables(): void {
+  db.run('PRAGMA foreign_keys = OFF')
+  try {
+    if (tableExists('collection_drafts')) {
+      db.run(`CREATE TABLE collection_drafts_v2 (
+        collection_id TEXT PRIMARY KEY REFERENCES folders(id) ON DELETE CASCADE,
+        name TEXT, description TEXT,
+        auth_type TEXT, auth_config TEXT, ssl_verification TEXT,
+        updated_at INTEGER NOT NULL
+      )`)
+      db.run(`
+        INSERT OR REPLACE INTO collection_drafts_v2
+          (collection_id, name, description, auth_type, auth_config, ssl_verification, updated_at)
+        SELECT collection_id, name, description, auth_type, auth_config, ssl_verification, updated_at
+        FROM collection_drafts
+      `)
+      db.run('DROP TABLE collection_drafts')
+      db.run('ALTER TABLE collection_drafts_v2 RENAME TO collection_drafts')
+    } else {
+      db.run(`CREATE TABLE IF NOT EXISTS collection_drafts (
+        collection_id TEXT PRIMARY KEY REFERENCES folders(id) ON DELETE CASCADE,
+        name TEXT, description TEXT,
+        auth_type TEXT, auth_config TEXT, ssl_verification TEXT,
+        updated_at INTEGER NOT NULL
+      )`)
+    }
+
+    if (tableExists('group_drafts')) {
+      db.run(`CREATE TABLE group_drafts_v2 (
+        group_id TEXT PRIMARY KEY REFERENCES folders(id) ON DELETE CASCADE,
+        name TEXT, description TEXT,
+        auth_type TEXT, auth_config TEXT, ssl_verification TEXT,
+        updated_at INTEGER NOT NULL
+      )`)
+      db.run(`
+        INSERT OR REPLACE INTO group_drafts_v2
+          (group_id, name, description, auth_type, auth_config, ssl_verification, updated_at)
+        SELECT group_id, name, description, auth_type, auth_config, ssl_verification, updated_at
+        FROM group_drafts
+      `)
+      db.run('DROP TABLE group_drafts')
+      db.run('ALTER TABLE group_drafts_v2 RENAME TO group_drafts')
+    } else {
+      db.run(`CREATE TABLE IF NOT EXISTS group_drafts (
+        group_id TEXT PRIMARY KEY REFERENCES folders(id) ON DELETE CASCADE,
+        name TEXT, description TEXT,
+        auth_type TEXT, auth_config TEXT, ssl_verification TEXT,
+        updated_at INTEGER NOT NULL
+      )`)
+    }
+  } finally {
+    db.run('PRAGMA foreign_keys = ON')
+  }
 }
 
 function runMigrations(): void {
@@ -47,10 +126,10 @@ function runMigrations(): void {
   // Collections: add description, auth_type, auth_config
   try { db.run("ALTER TABLE collections ADD COLUMN description TEXT DEFAULT ''") } catch {}
   try { db.run("ALTER TABLE collections ADD COLUMN auth_type TEXT DEFAULT 'none'") } catch {}
-  try { db.run("ALTER TABLE collections ADD COLUMN auth_config TEXT DEFAULT '{}'") } catch {}
+  try { db.run("ALTER TABLE collections ADD COLUMN auth_config TEXT DEFAULT '{}'" ) } catch {}
   // Groups: add auth columns (description already exists)
   try { db.run("ALTER TABLE groups ADD COLUMN auth_type TEXT DEFAULT 'none'") } catch {}
-  try { db.run("ALTER TABLE groups ADD COLUMN auth_config TEXT DEFAULT '{}'") } catch {}
+  try { db.run("ALTER TABLE groups ADD COLUMN auth_config TEXT DEFAULT '{}'" ) } catch {}
   try { db.run("ALTER TABLE groups ADD COLUMN ssl_verification TEXT DEFAULT 'inherit'") } catch {}
   // Collections ssl
   try { db.run("ALTER TABLE collections ADD COLUMN ssl_verification TEXT DEFAULT 'inherit'") } catch {}
@@ -58,11 +137,123 @@ function runMigrations(): void {
   try { db.run("ALTER TABLE requests ADD COLUMN ssl_verification TEXT DEFAULT 'inherit'") } catch {}
   // Requests protocol support
   try { db.run("ALTER TABLE requests ADD COLUMN protocol TEXT NOT NULL DEFAULT 'http'") } catch {}
-  try { db.run("ALTER TABLE requests ADD COLUMN protocol_config TEXT NOT NULL DEFAULT '{}'") } catch {}
+  try { db.run("ALTER TABLE requests ADD COLUMN protocol_config TEXT NOT NULL DEFAULT '{}'" ) } catch {}
   // Collections collapsed state
   try { db.run('ALTER TABLE collections ADD COLUMN collapsed INTEGER NOT NULL DEFAULT 0') } catch {}
   // Integrations ssl verification
   try { db.run("ALTER TABLE integrations ADD COLUMN ssl_verification TEXT NOT NULL DEFAULT 'enabled'") } catch {}
+
+  db.run(`CREATE TABLE IF NOT EXISTS folders (
+    id TEXT PRIMARY KEY,
+    parent_id TEXT REFERENCES folders(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    source TEXT NOT NULL DEFAULT 'local',
+    source_meta TEXT,
+    integration_id TEXT REFERENCES integrations(id),
+    auth_type TEXT NOT NULL DEFAULT 'none',
+    auth_config TEXT NOT NULL DEFAULT '{}',
+    ssl_verification TEXT NOT NULL DEFAULT 'inherit',
+    hidden INTEGER NOT NULL DEFAULT 0,
+    collapsed INTEGER NOT NULL DEFAULT 0,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`)
+
+  if (tableExists('collections')) {
+    db.run(`
+      INSERT OR IGNORE INTO folders
+      SELECT
+        id,
+        NULL AS parent_id,
+        name,
+        COALESCE(description, ''),
+        source,
+        source_meta,
+        integration_id,
+        COALESCE(auth_type, 'none'),
+        COALESCE(auth_config, '{}'),
+        COALESCE(ssl_verification, 'inherit'),
+        0,
+        COALESCE(collapsed, 0),
+        0,
+        created_at,
+        updated_at
+      FROM collections
+    `)
+  }
+
+  if (tableExists('groups')) {
+    db.run(`
+      INSERT OR IGNORE INTO folders
+      SELECT
+        id,
+        collection_id AS parent_id,
+        name,
+        COALESCE(description, ''),
+        'local',
+        NULL,
+        NULL,
+        COALESCE(auth_type, 'none'),
+        COALESCE(auth_config, '{}'),
+        COALESCE(ssl_verification, 'inherit'),
+        hidden,
+        collapsed,
+        sort_order,
+        created_at,
+        updated_at
+      FROM groups
+    `)
+  }
+
+  if (!hasColumn('requests', 'folder_id') && hasColumn('requests', 'group_id')) {
+    db.run('PRAGMA foreign_keys = OFF')
+    try {
+      db.run(`CREATE TABLE requests_v2 (
+        id TEXT PRIMARY KEY,
+        folder_id TEXT NOT NULL REFERENCES folders(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        method TEXT NOT NULL DEFAULT 'GET',
+        url TEXT NOT NULL DEFAULT '',
+        params TEXT NOT NULL DEFAULT '[]',
+        headers TEXT NOT NULL DEFAULT '[]',
+        body_type TEXT NOT NULL DEFAULT 'none',
+        body_content TEXT NOT NULL DEFAULT '',
+        auth_type TEXT NOT NULL DEFAULT 'none',
+        auth_config TEXT NOT NULL DEFAULT '{}',
+        description TEXT,
+        scm_path TEXT,
+        scm_sha TEXT,
+        is_dirty INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        ssl_verification TEXT NOT NULL DEFAULT 'inherit',
+        protocol TEXT NOT NULL DEFAULT 'http',
+        protocol_config TEXT NOT NULL DEFAULT '{}'
+      )`)
+      db.run(`
+        INSERT INTO requests_v2
+          (id, folder_id, name, method, url, params, headers, body_type, body_content,
+           auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order,
+           created_at, updated_at, ssl_verification, protocol, protocol_config)
+        SELECT
+          id, group_id AS folder_id, name, method, url, params, headers, body_type, body_content,
+          auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order,
+          created_at, updated_at,
+          COALESCE(ssl_verification, 'inherit'),
+          COALESCE(protocol, 'http'),
+          COALESCE(protocol_config, '{}')
+        FROM requests
+      `)
+      db.run('DROP TABLE requests')
+      db.run('ALTER TABLE requests_v2 RENAME TO requests')
+    } finally {
+      db.run('PRAGMA foreign_keys = ON')
+    }
+  }
+
   // Draft cache tables (Issue #14) — changes are auto-saved here until explicit save
   db.run(`CREATE TABLE IF NOT EXISTS request_drafts (
     request_id TEXT PRIMARY KEY REFERENCES requests(id) ON DELETE CASCADE,
@@ -72,18 +263,7 @@ function runMigrations(): void {
     ssl_verification TEXT, protocol TEXT, protocol_config TEXT,
     updated_at INTEGER NOT NULL
   )`)
-  db.run(`CREATE TABLE IF NOT EXISTS collection_drafts (
-    collection_id TEXT PRIMARY KEY REFERENCES collections(id) ON DELETE CASCADE,
-    name TEXT, description TEXT,
-    auth_type TEXT, auth_config TEXT, ssl_verification TEXT,
-    updated_at INTEGER NOT NULL
-  )`)
-  db.run(`CREATE TABLE IF NOT EXISTS group_drafts (
-    group_id TEXT PRIMARY KEY REFERENCES groups(id) ON DELETE CASCADE,
-    name TEXT, description TEXT,
-    auth_type TEXT, auth_config TEXT, ssl_verification TEXT,
-    updated_at INTEGER NOT NULL
-  )`)
+  recreateDraftTables()
   db.run(`CREATE TABLE IF NOT EXISTS env_drafts (
     env_id TEXT PRIMARY KEY REFERENCES environments(id) ON DELETE CASCADE,
     vars_json TEXT NOT NULL,

--- a/src/main/database/migrations.ts
+++ b/src/main/database/migrations.ts
@@ -4,22 +4,19 @@ export const migrations: string[] = [
     value TEXT
   )`,
 
-  `CREATE TABLE IF NOT EXISTS collections (
+  `CREATE TABLE IF NOT EXISTS folders (
     id TEXT PRIMARY KEY,
-    name TEXT NOT NULL,
-    source TEXT NOT NULL DEFAULT 'local',
-    source_meta TEXT,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
-  )`,
-
-  `CREATE TABLE IF NOT EXISTS groups (
-    id TEXT PRIMARY KEY,
-    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    parent_id TEXT REFERENCES folders(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     description TEXT,
-    collapsed INTEGER NOT NULL DEFAULT 0,
+    source TEXT NOT NULL DEFAULT 'local',
+    source_meta TEXT,
+    integration_id TEXT REFERENCES integrations(id),
+    auth_type TEXT NOT NULL DEFAULT 'none',
+    auth_config TEXT NOT NULL DEFAULT '{}',
+    ssl_verification TEXT NOT NULL DEFAULT 'inherit',
     hidden INTEGER NOT NULL DEFAULT 0,
+    collapsed INTEGER NOT NULL DEFAULT 0,
     sort_order INTEGER NOT NULL DEFAULT 0,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
@@ -27,7 +24,7 @@ export const migrations: string[] = [
 
   `CREATE TABLE IF NOT EXISTS requests (
     id TEXT PRIMARY KEY,
-    group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    folder_id TEXT NOT NULL REFERENCES folders(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     method TEXT NOT NULL DEFAULT 'GET',
     url TEXT NOT NULL DEFAULT '',
@@ -105,3 +102,49 @@ export const migrations: string[] = [
     updated_at INTEGER NOT NULL
   )`,
 ]
+
+/*
+Legacy schema reference:
+
+CREATE TABLE IF NOT EXISTS collections (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'local',
+  source_meta TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)
+
+CREATE TABLE IF NOT EXISTS groups (
+  id TEXT PRIMARY KEY,
+  collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  collapsed INTEGER NOT NULL DEFAULT 0,
+  hidden INTEGER NOT NULL DEFAULT 0,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)
+
+CREATE TABLE IF NOT EXISTS requests (
+  id TEXT PRIMARY KEY,
+  group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  method TEXT NOT NULL DEFAULT 'GET',
+  url TEXT NOT NULL DEFAULT '',
+  params TEXT NOT NULL DEFAULT '[]',
+  headers TEXT NOT NULL DEFAULT '[]',
+  body_type TEXT NOT NULL DEFAULT 'none',
+  body_content TEXT NOT NULL DEFAULT '',
+  auth_type TEXT NOT NULL DEFAULT 'none',
+  auth_config TEXT NOT NULL DEFAULT '{}',
+  description TEXT,
+  scm_path TEXT,
+  scm_sha TEXT,
+  is_dirty INTEGER NOT NULL DEFAULT 0,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+)
+*/

--- a/src/main/ipc/__tests__/collections.test.ts
+++ b/src/main/ipc/__tests__/collections.test.ts
@@ -95,3 +95,61 @@ describe('postly:collections:update', () => {
     expect(params).toContain('root-1')
   })
 })
+
+describe('postly:reorder', () => {
+  it('updates sort_order for a folder without changing parent', async () => {
+    await handlers['postly:reorder'](null, {
+      type: 'folder',
+      updates: [{ id: 'f1', sortOrder: 2 }],
+    })
+
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('sort_order = ?')
+    expect(sql).not.toContain('parent_id')
+    expect(params).toContain(2)
+  })
+
+  it('sets parent_id to a new folder id when moving a folder between parents', async () => {
+    await handlers['postly:reorder'](null, {
+      type: 'folder',
+      updates: [{ id: 'f1', sortOrder: 0, newParentId: 'parent-2' }],
+    })
+
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('parent_id = ?')
+    expect(params).toContain('parent-2')
+  })
+
+  it('sets parent_id to NULL when moving a folder to the root level (newParentId = null)', async () => {
+    await handlers['postly:reorder'](null, {
+      type: 'folder',
+      updates: [{ id: 'f1', sortOrder: 0, newParentId: null }],
+    })
+
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('parent_id = ?')
+    // null must be passed so SQLite stores NULL — not undefined which would skip the update
+    expect(params).toContain(null)
+  })
+
+  it('does NOT update parent_id when newParentId is absent (reorder within same parent)', async () => {
+    await handlers['postly:reorder'](null, {
+      type: 'folder',
+      updates: [{ id: 'f1', sortOrder: 1 }],
+    })
+
+    const [sql] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).not.toContain('parent_id')
+  })
+
+  it('sets folder_id when moving a request to a different folder', async () => {
+    await handlers['postly:reorder'](null, {
+      type: 'request',
+      updates: [{ id: 'r1', sortOrder: 0, newParentId: 'f2' }],
+    })
+
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('folder_id = ?')
+    expect(params).toContain('f2')
+  })
+})

--- a/src/main/ipc/__tests__/collections.test.ts
+++ b/src/main/ipc/__tests__/collections.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Capture registered handlers by channel name so tests can call them directly.
 const handlers: Record<string, (ev: unknown, args: unknown) => Promise<unknown>> = {}
 
 vi.mock('electron', () => ({
@@ -30,22 +29,15 @@ beforeEach(() => {
   registerCollectionHandlers()
 })
 
-// ── list ─────────────────────────────────────────────────────────────────────
-
 describe('postly:collections:list', () => {
-  it('returns collections and groups from the database', async () => {
-    const cols = [{ id: 'c1', name: 'My API', collapsed: 0 }]
-    const grps = [{ id: 'g1', collection_id: 'c1', name: 'Default', collapsed: 0 }]
-    mockQueryAll
-      .mockReturnValueOnce(cols)
-      .mockReturnValueOnce(grps)
+  it('returns folders from the database', async () => {
+    const folders = [{ id: 'c1', name: 'My API', parent_id: null, collapsed: 0 }]
+    mockQueryAll.mockReturnValueOnce(folders)
 
     const result = await handlers['postly:collections:list'](null, undefined) as { data: unknown }
-    expect(result.data).toEqual({ collections: cols, groups: grps })
+    expect(result.data).toEqual(folders)
   })
 })
-
-// ── update ───────────────────────────────────────────────────────────────────
 
 describe('postly:collections:update', () => {
   it('persists collapsed=true as integer 1', async () => {
@@ -55,7 +47,6 @@ describe('postly:collections:update', () => {
     }) as { data: unknown }
 
     expect(result.data).toBe(true)
-    expect(mockRun).toHaveBeenCalledOnce()
     const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
     expect(sql).toContain('collapsed = ?')
     expect(params).toContain(1)
@@ -78,7 +69,6 @@ describe('postly:collections:update', () => {
 
   it('returns data:true with no-op when no fields provided', async () => {
     const result = await handlers['postly:collections:update'](null, { id: 'c1' }) as { data: unknown }
-
     expect(result.data).toBe(true)
     expect(mockRun).not.toHaveBeenCalled()
   })
@@ -95,5 +85,13 @@ describe('postly:collections:update', () => {
     expect(sql).toContain('collapsed = ?')
     expect(params).toContain('Updated')
     expect(params).toContain(1)
+  })
+
+  it('maps parentId to parent_id for folder moves', async () => {
+    await handlers['postly:collections:update'](null, { id: 'f1', parentId: 'root-1' })
+
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('parent_id = ?')
+    expect(params).toContain('root-1')
   })
 })

--- a/src/main/ipc/__tests__/collections.test.ts
+++ b/src/main/ipc/__tests__/collections.test.ts
@@ -19,9 +19,10 @@ vi.mock('../../database', () => ({
 vi.mock('../../services/git-local', () => ({}))
 
 import { registerCollectionHandlers } from '../collections'
-import { queryAll, run } from '../../database'
+import { queryAll, queryOne, run } from '../../database'
 
 const mockQueryAll = vi.mocked(queryAll)
+const mockQueryOne = vi.mocked(queryOne)
 const mockRun = vi.mocked(run)
 
 beforeEach(() => {
@@ -36,6 +37,118 @@ describe('postly:collections:list', () => {
 
     const result = await handlers['postly:collections:list'](null, undefined) as { data: unknown }
     expect(result.data).toEqual(folders)
+  })
+})
+
+describe('postly:folders:create', () => {
+  it('creates a root folder with local defaults when parentId is null', async () => {
+    mockQueryOne.mockReturnValueOnce({ id: 'root-1' })
+
+    const result = await handlers['postly:folders:create'](null, {
+      name: 'New API',
+      parentId: null,
+    }) as { data: unknown }
+
+    expect(result.data).toEqual({ id: 'root-1' })
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('INSERT INTO folders')
+    expect(sql).toContain("'none'")
+    expect(sql).toContain("'{}'")
+    expect(sql).toContain("'inherit'")
+    expect(sql).toContain('hidden, collapsed, sort_order')
+    expect(params[1]).toBeNull()
+    expect(params[2]).toBe('New API')
+    expect(params[3]).toBe('local')
+    expect(params[4]).toBeNull()
+  })
+
+  it('creates a sub-folder with a parentId', async () => {
+    mockQueryOne.mockReturnValueOnce({ id: 'child-1' })
+
+    await handlers['postly:folders:create'](null, {
+      name: 'Endpoints',
+      parentId: 'root-1',
+    })
+
+    const [, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(params[1]).toBe('root-1')
+  })
+
+  it('returns the created folder row', async () => {
+    const created = { id: 'folder-1', parent_id: null, name: 'Imported API', source: 'local' }
+    mockQueryOne.mockReturnValueOnce(created)
+
+    const result = await handlers['postly:folders:create'](null, { name: 'Imported API' }) as { data: unknown }
+
+    expect(result.data).toEqual(created)
+    expect(mockQueryOne).toHaveBeenCalledWith('SELECT * FROM folders WHERE id = ?', [expect.any(String)])
+  })
+
+  it('wraps errors', async () => {
+    mockRun.mockImplementationOnce(() => { throw new Error('insert failed') })
+
+    const result = await handlers['postly:folders:create'](null, { name: 'Broken API' }) as { error: string }
+    expect(result.error).toContain('insert failed')
+  })
+})
+
+describe('postly:folders:rename', () => {
+  it('updates the name field only', async () => {
+    const result = await handlers['postly:folders:rename'](null, {
+      id: 'f1',
+      name: 'Renamed Folder',
+    }) as { data: unknown }
+
+    expect(result.data).toBe(true)
+    const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toBe('UPDATE folders SET name = ?, updated_at = ? WHERE id = ?')
+    expect(params[0]).toBe('Renamed Folder')
+    expect(params[2]).toBe('f1')
+  })
+
+  it('wraps errors', async () => {
+    mockRun.mockImplementationOnce(() => { throw new Error('rename failed') })
+
+    const result = await handlers['postly:folders:rename'](null, {
+      id: 'f1',
+      name: 'Renamed Folder',
+    }) as { error: string }
+
+    expect(result.error).toContain('rename failed')
+  })
+})
+
+describe('postly:folders:delete', () => {
+  it('deletes a local folder with a direct DELETE', async () => {
+    mockQueryOne.mockReturnValueOnce({
+      id: 'f1',
+      parent_id: null,
+      name: 'Local Folder',
+      source: 'local',
+      source_meta: null,
+      integration_id: null,
+    })
+
+    const result = await handlers['postly:folders:delete'](null, { id: 'f1' }) as { data: unknown }
+
+    expect(result.data).toBe(true)
+    expect(mockQueryOne).toHaveBeenCalledTimes(1)
+    expect(mockRun).toHaveBeenCalledWith('DELETE FROM folders WHERE id = ?', ['f1'])
+  })
+
+  it('wraps errors', async () => {
+    mockQueryOne.mockReturnValueOnce({
+      id: 'f1',
+      parent_id: null,
+      name: 'Local Folder',
+      source: 'local',
+      source_meta: null,
+      integration_id: null,
+    })
+    mockRun.mockImplementationOnce(() => { throw new Error('delete failed') })
+
+    const result = await handlers['postly:folders:delete'](null, { id: 'f1' }) as { error: string }
+    expect(result.error).toContain('delete failed')
   })
 })
 

--- a/src/main/ipc/__tests__/export-import.test.ts
+++ b/src/main/ipc/__tests__/export-import.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// ── DB mock ───────────────────────────────────────────────────────────────────
-
 vi.mock('../../database', () => ({
   queryAll: vi.fn(),
   run: vi.fn(),
@@ -14,10 +12,7 @@ import type { PostlyExportFile } from '../export-import'
 const mockQueryAll = vi.mocked(queryAll)
 const mockRun = vi.mocked(run)
 
-// resetAllMocks also clears the mockReturnValueOnce queue between tests
 beforeEach(() => vi.resetAllMocks())
-
-// ── tryParse ──────────────────────────────────────────────────────────────────
 
 describe('tryParse', () => {
   it('parses a valid JSON string', () => {
@@ -35,88 +30,135 @@ describe('tryParse', () => {
   })
 })
 
-// ── buildExport ───────────────────────────────────────────────────────────────
-
 describe('buildExport', () => {
-  function setupDb(cols: object[], groups: object[], requests: object[]) {
-    mockQueryAll
-      .mockReturnValueOnce(cols)     // collections query
-      .mockReturnValueOnce(groups)   // groups for col[0]
-      .mockReturnValueOnce(requests) // requests for grp[0]
-    // Note: no integration query mock here — tests that need it add it themselves
-  }
-
   it('returns a file with the correct schema string', () => {
-    setupDb(
-      [{ id: 'c1', name: 'My API', source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit' }],
-      [{ id: 'g1', collection_id: 'c1', name: 'Default', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit' }],
-      [],
-    )
+    mockQueryAll
+      .mockReturnValueOnce([{ id: 'c1', parent_id: null, name: 'My API', source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 }])
+      .mockReturnValueOnce([])
 
     const file = buildExport()
     expect(file.$schema).toBe('postly/v1')
     expect(file.exportedAt).toBeTruthy()
   })
 
-  it('serializes a collection with groups and requests', () => {
-    const col = { id: 'c1', name: 'API', source: 'local', description: 'desc', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', integration_id: null }
-    const grp = { id: 'g1', collection_id: 'c1', name: 'Default', description: '', auth_type: 'bearer', auth_config: '{"token":"t"}', ssl_verification: 'verify' }
-    const req = { id: 'r1', group_id: 'g1', name: 'Get Users', method: 'GET', url: '/users', protocol: 'http', params: '[]', headers: '[]', body_type: 'none', body_content: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', description: '', protocol_config: '{}' }
+  it('serializes a recursive collection tree with requests in a sub-folder', () => {
+    const folderRows = [
+      { id: 'c1', parent_id: null, name: 'API', source: 'local', description: 'desc', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 },
+      { id: 'f1', parent_id: 'c1', name: 'Default', source: 'local', description: '', auth_type: 'bearer', auth_config: '{"token":"t"}', ssl_verification: 'inherit', sort_order: 0 },
+    ]
+    const requestRows = [
+      { id: 'r1', folder_id: 'f1', name: 'Get Users', method: 'GET', url: '/users', protocol: 'http', params: '[]', headers: '[]', body_type: 'none', body_content: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', description: '', protocol_config: '{}', sort_order: 0 },
+    ]
 
     mockQueryAll
-      .mockReturnValueOnce([col])
-      .mockReturnValueOnce([grp])
-      .mockReturnValueOnce([req])
-      .mockReturnValueOnce([]) // integration
+      .mockReturnValueOnce(folderRows)
+      .mockReturnValueOnce(requestRows)
 
     const file = buildExport()
     expect(file.collections).toHaveLength(1)
-
     const exported = file.collections[0]
     expect(exported.name).toBe('API')
-    expect(exported.groups).toHaveLength(1)
-    expect(exported.groups[0].requests).toHaveLength(1)
-    expect(exported.groups[0].requests[0].name).toBe('Get Users')
-    expect(exported.groups[0].requests[0].method).toBe('GET')
+    expect(exported.requests).toHaveLength(0)
+    expect(exported.folders).toHaveLength(1)
+    expect(exported.folders[0].requests).toHaveLength(1)
+    expect(exported.folders[0].requests[0].name).toBe('Get Users')
+  })
+
+  it('serializes requests placed directly at collection level (no sub-folder)', () => {
+    const folderRows = [
+      { id: 'c1', parent_id: null, name: 'Simple API', source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 },
+    ]
+    const requestRows = [
+      { id: 'r1', folder_id: 'c1', name: 'Health Check', method: 'GET', url: '/health', protocol: 'http', params: '[]', headers: '[]', body_type: 'none', body_content: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', description: '', protocol_config: '{}', sort_order: 0 },
+    ]
+
+    mockQueryAll.mockReturnValueOnce(folderRows).mockReturnValueOnce(requestRows)
+
+    const file = buildExport()
+    const col = file.collections[0]
+    expect(col.requests).toHaveLength(1)
+    expect(col.requests[0].name).toBe('Health Check')
+    expect(col.folders).toHaveLength(0)
+  })
+
+  it('serializes deeply nested folders (3 levels)', () => {
+    const folderRows = [
+      { id: 'c1', parent_id: null,  name: 'Root',   source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 },
+      { id: 'f1', parent_id: 'c1', name: 'Level 1', source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 },
+      { id: 'f2', parent_id: 'f1', name: 'Level 2', source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 },
+    ]
+    const requestRows = [
+      { id: 'r1', folder_id: 'f2', name: 'Deep Request', method: 'POST', url: '/deep', protocol: 'http', params: '[]', headers: '[]', body_type: 'json', body_content: '{}', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', description: '', protocol_config: '{}', sort_order: 0 },
+    ]
+
+    mockQueryAll.mockReturnValueOnce(folderRows).mockReturnValueOnce(requestRows)
+
+    const file = buildExport()
+    const col = file.collections[0]
+    expect(col.folders).toHaveLength(1)
+    expect(col.folders[0].name).toBe('Level 1')
+    expect(col.folders[0].folders).toHaveLength(1)
+    expect(col.folders[0].folders[0].name).toBe('Level 2')
+    expect(col.folders[0].folders[0].requests).toHaveLength(1)
+    expect(col.folders[0].folders[0].requests[0].name).toBe('Deep Request')
+  })
+
+  it('serializes auth config on sub-folders', () => {
+    const folderRows = [
+      { id: 'c1', parent_id: null, name: 'API', source: 'local', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', sort_order: 0 },
+      { id: 'f1', parent_id: 'c1', name: 'Secured', source: 'local', description: '', auth_type: 'bearer', auth_config: '{"token":"secret"}', ssl_verification: 'false', sort_order: 0 },
+    ]
+
+    mockQueryAll.mockReturnValueOnce(folderRows).mockReturnValueOnce([])
+
+    const file = buildExport()
+    const folder = file.collections[0].folders[0]
+    expect(folder.auth.type).toBe('bearer')
+    expect(folder.auth.config).toEqual({ token: 'secret' })
+    expect(folder.ssl).toBe('false')
   })
 
   it('filters collections when collectionIds is provided', () => {
     mockQueryAll
-      .mockReturnValueOnce([]) // no collections (filtered result)
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([])
 
     const file = buildExport(['c-specific'])
     expect(file.collections).toHaveLength(0)
 
     const [sql, params] = mockQueryAll.mock.calls[0] as [string, unknown[]]
-    expect(sql).toContain('WHERE id IN')
+    expect(sql).toContain('WITH RECURSIVE tree')
     expect(params).toContain('c-specific')
   })
 
   it('uses all collections when no ids are passed', () => {
-    mockQueryAll.mockReturnValueOnce([])
+    mockQueryAll.mockReturnValueOnce([]).mockReturnValueOnce([])
 
     buildExport()
 
     const [sql] = mockQueryAll.mock.calls[0] as [string, unknown[]]
-    expect(sql).not.toContain('WHERE id IN')
-  })
-
-  it('attaches integrationName when the collection has an integration', () => {
-    const col = { id: 'c1', name: 'GitHub', source: 'github', description: '', auth_type: 'none', auth_config: '{}', ssl_verification: 'inherit', integration_id: 'int-1' }
-
-    mockQueryAll
-      .mockReturnValueOnce([col])
-      .mockReturnValueOnce([]) // no groups
-      .mockReturnValueOnce([{ name: 'My GitHub Integration' }]) // integration lookup
-
-    const file = buildExport()
-    expect(file.collections[0].integrationName).toBe('My GitHub Integration')
+    expect(sql).not.toContain('WITH RECURSIVE tree')
   })
 })
 
-// ── importData ────────────────────────────────────────────────────────────────
-
 describe('importData', () => {
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  const baseRequest = {
+    name: 'Get Users',
+    method: 'GET',
+    url: '/users',
+    protocol: 'http',
+    params: [],
+    headers: [],
+    bodyType: 'none',
+    bodyContent: '',
+    auth: { type: 'none', config: {} },
+    ssl: 'inherit',
+    description: '',
+    protocolConfig: {},
+  }
+
   function makeFile(overrides: Partial<PostlyExportFile> = {}): PostlyExportFile {
     return {
       $schema: 'postly/v1',
@@ -128,28 +170,15 @@ describe('importData', () => {
           source: 'local',
           auth: { type: 'none', config: {} },
           ssl: 'inherit',
-          groups: [
+          requests: [],
+          folders: [
             {
               name: 'Default',
               description: '',
               auth: { type: 'none', config: {} },
               ssl: 'inherit',
-              requests: [
-                {
-                  name: 'Get Users',
-                  method: 'GET',
-                  url: '/users',
-                  protocol: 'http',
-                  params: [],
-                  headers: [],
-                  bodyType: 'none',
-                  bodyContent: '',
-                  auth: { type: 'none', config: {} },
-                  ssl: 'inherit',
-                  description: '',
-                  protocolConfig: {},
-                },
-              ],
+              requests: [{ ...baseRequest }],
+              folders: [],
             },
           ],
         },
@@ -158,50 +187,337 @@ describe('importData', () => {
     }
   }
 
+  function insertCalls() {
+    return mockRun.mock.calls.filter(([sql]) => (sql as string).startsWith('INSERT'))
+  }
+
+  function folderInserts() {
+    return insertCalls().filter(([sql]) => (sql as string).includes('INSERT INTO folders'))
+  }
+
+  function requestInserts() {
+    return insertCalls().filter(([sql]) => (sql as string).includes('INSERT INTO requests'))
+  }
+
+  // ── basic ─────────────────────────────────────────────────────────────────
+
   it('returns the number of imported collections', () => {
-    const count = importData(makeFile())
-    expect(count).toBe(1)
+    expect(importData(makeFile())).toBe(1)
   })
 
-  it('inserts one collection, one group, and one request row', () => {
+  it('inserts one collection folder, one sub-folder, and one request row', () => {
     importData(makeFile())
-
-    const insertCalls = mockRun.mock.calls.filter(([sql]) => (sql as string).startsWith('INSERT'))
-    expect(insertCalls).toHaveLength(3) // collection + group + request
-    const sqls = insertCalls.map(([sql]) => sql as string)
-    expect(sqls.some((s) => s.includes('INSERT INTO collections'))).toBe(true)
-    expect(sqls.some((s) => s.includes('INSERT INTO groups'))).toBe(true)
-    expect(sqls.some((s) => s.includes('INSERT INTO requests'))).toBe(true)
+    expect(folderInserts()).toHaveLength(2)
+    expect(requestInserts()).toHaveLength(1)
   })
 
   it('handles multiple collections', () => {
     const file = makeFile()
     file.collections = [...file.collections, { ...file.collections[0], name: 'Second API' }]
-
-    const count = importData(file)
-    expect(count).toBe(2)
+    expect(importData(file)).toBe(2)
   })
 
   it('preserves request fields (url, method, bodyType)', () => {
     importData(makeFile())
-
-    const reqInsert = mockRun.mock.calls.find(([sql]) => (sql as string).includes('INSERT INTO requests'))
-    expect(reqInsert).toBeDefined()
-    const params = (reqInsert as unknown[][])[1] as unknown[]
+    const params = requestInserts()[0][1] as unknown[]
     expect(params).toContain('Get Users')
     expect(params).toContain('GET')
     expect(params).toContain('/users')
-    expect(params).toContain('none') // bodyType
   })
 
   it('uses default values for optional fields when absent', () => {
     const file = makeFile()
-    const req = file.collections[0].groups[0].requests[0]
-    // Remove optional fields to simulate a minimal import
+    const req = file.collections[0].folders[0].requests[0]
     delete (req as unknown as Record<string, unknown>).description
     delete (req as unknown as Record<string, unknown>).protocolConfig
-
-    // Should not throw
     expect(() => importData(file)).not.toThrow()
+  })
+
+  // ── new format ────────────────────────────────────────────────────────────
+
+  describe('new format (folders)', () => {
+    it('imports requests placed directly at collection level', () => {
+      const file: PostlyExportFile = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Flat API',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            requests: [{ ...baseRequest, name: 'Health', url: '/health' }],
+            folders: [],
+          },
+        ],
+      }
+
+      importData(file)
+
+      // 1 root folder, 0 sub-folders, 1 request
+      expect(folderInserts()).toHaveLength(1)
+      expect(requestInserts()).toHaveLength(1)
+      const reqParams = requestInserts()[0][1] as unknown[]
+      expect(reqParams).toContain('Health')
+    })
+
+    it('imports 3-level deeply nested folders', () => {
+      const file: PostlyExportFile = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Deep API',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            requests: [],
+            folders: [
+              {
+                name: 'Level 1',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [],
+                folders: [
+                  {
+                    name: 'Level 2',
+                    description: '',
+                    auth: { type: 'none', config: {} },
+                    ssl: 'inherit',
+                    requests: [{ ...baseRequest, name: 'Deep Request', url: '/deep' }],
+                    folders: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+
+      importData(file)
+
+      // 1 root + Level1 + Level2 = 3 folder inserts, 1 request
+      expect(folderInserts()).toHaveLength(3)
+      expect(requestInserts()).toHaveLength(1)
+      const reqParams = requestInserts()[0][1] as unknown[]
+      expect(reqParams).toContain('Deep Request')
+    })
+
+    it('imports requests at multiple folder levels in the same collection', () => {
+      const file: PostlyExportFile = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Mixed API',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            requests: [{ ...baseRequest, name: 'Root Request', url: '/root' }],
+            folders: [
+              {
+                name: 'Sub',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [{ ...baseRequest, name: 'Sub Request', url: '/sub' }],
+                folders: [],
+              },
+            ],
+          },
+        ],
+      }
+
+      importData(file)
+
+      expect(folderInserts()).toHaveLength(2)   // root + Sub
+      expect(requestInserts()).toHaveLength(2)  // Root Request + Sub Request
+    })
+
+    it('preserves auth config on imported sub-folders', () => {
+      const file: PostlyExportFile = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Auth API',
+            description: '',
+            source: 'local',
+            auth: { type: 'bearer', config: { token: 'root-token' } },
+            ssl: 'inherit',
+            requests: [],
+            folders: [
+              {
+                name: 'Secured',
+                description: '',
+                auth: { type: 'bearer', config: { token: 'folder-token' } },
+                ssl: 'false',
+                requests: [],
+                folders: [],
+              },
+            ],
+          },
+        ],
+      }
+
+      importData(file)
+
+      const allFolderParams = folderInserts().map(([, params]) => params as unknown[])
+      // root folder auth
+      expect(allFolderParams[0]).toContain('bearer')
+      expect(allFolderParams[0]).toContain(JSON.stringify({ token: 'root-token' }))
+      // sub-folder auth + ssl
+      expect(allFolderParams[1]).toContain('bearer')
+      expect(allFolderParams[1]).toContain(JSON.stringify({ token: 'folder-token' }))
+      expect(allFolderParams[1]).toContain('false')
+    })
+  })
+
+  // ── old format ────────────────────────────────────────────────────────────
+
+  describe('old format (groups)', () => {
+    it('imports a single group with requests', () => {
+      const oldFormat = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Legacy API',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            groups: [
+              {
+                name: 'Default',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [{ ...baseRequest, name: 'List items', url: '/items' }],
+              },
+            ],
+          },
+        ],
+      } as unknown as PostlyExportFile
+
+      const count = importData(oldFormat)
+      expect(count).toBe(1)
+      // 1 root folder + 1 group-as-subfolder + 1 request
+      expect(folderInserts()).toHaveLength(2)
+      expect(requestInserts()).toHaveLength(1)
+      const reqParams = requestInserts()[0][1] as unknown[]
+      expect(reqParams).toContain('List items')
+    })
+
+    it('imports multiple groups each with multiple requests', () => {
+      const oldFormat = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Big API',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            groups: [
+              {
+                name: 'Users',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [
+                  { ...baseRequest, name: 'List users', url: '/users' },
+                  { ...baseRequest, name: 'Create user', method: 'POST', url: '/users' },
+                ],
+              },
+              {
+                name: 'Orders',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [
+                  { ...baseRequest, name: 'List orders', url: '/orders' },
+                ],
+              },
+            ],
+          },
+        ],
+      } as unknown as PostlyExportFile
+
+      importData(oldFormat)
+
+      // 1 root + 2 groups = 3 folder inserts, 3 requests
+      expect(folderInserts()).toHaveLength(3)
+      expect(requestInserts()).toHaveLength(3)
+    })
+
+    it('does not import any requests when both folders and groups are absent', () => {
+      const oldFormat = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'Empty',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+          },
+        ],
+      } as unknown as PostlyExportFile
+
+      importData(oldFormat)
+
+      expect(folderInserts()).toHaveLength(1)  // root folder only
+      expect(requestInserts()).toHaveLength(0)
+    })
+
+    it('prefers folders over groups when both are present (forward-compat)', () => {
+      const mixedFormat = {
+        $schema: 'postly/v1',
+        exportedAt: new Date().toISOString(),
+        collections: [
+          {
+            name: 'API',
+            description: '',
+            source: 'local',
+            auth: { type: 'none', config: {} },
+            ssl: 'inherit',
+            folders: [
+              {
+                name: 'New Folder',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [{ ...baseRequest, name: 'From folders', url: '/new' }],
+                folders: [],
+              },
+            ],
+            groups: [
+              {
+                name: 'Old Group',
+                description: '',
+                auth: { type: 'none', config: {} },
+                ssl: 'inherit',
+                requests: [{ ...baseRequest, name: 'From groups', url: '/old' }],
+              },
+            ],
+          },
+        ],
+      } as unknown as PostlyExportFile
+
+      importData(mixedFormat)
+
+      // folders takes precedence — only "New Folder" sub-folder, not "Old Group"
+      expect(folderInserts()).toHaveLength(2)
+      expect(requestInserts()).toHaveLength(1)
+      const reqParams = requestInserts()[0][1] as unknown[]
+      expect(reqParams).toContain('From folders')
+    })
   })
 })

--- a/src/main/ipc/__tests__/http.test.ts
+++ b/src/main/ipc/__tests__/http.test.ts
@@ -47,21 +47,56 @@ type Result = { data?: Record<string, unknown> & { logs: LogEntry[] }; error?: s
 function setupDb({
   envName = null as string | null,
   envVars = [] as { key: string; value: string }[],
-  group = null as Record<string, unknown> | null,
+  folder = null as Record<string, unknown> | null,
   collection = null as Record<string, unknown> | null,
   integration = null as Record<string, unknown> | null,
   settings = null as string | null,
 } = {}) {
   mockQ1.mockImplementation((sql: string) => {
     if (sql.includes('environments')) return envName ? { id: 'e1', name: envName } : null
-    if (sql.includes('groups')) return group
-    if (sql.includes('collections')) return collection
     if (sql.includes('integrations')) return integration
     if (sql.includes('settings')) return settings ? { value: settings } : null
     return null
   })
   mockQA.mockImplementation((sql: string) => {
     if (sql.includes('env_vars')) return envVars
+    if (sql.includes('WITH RECURSIVE lineage')) {
+      if (!folder) return []
+      // Build a lineage array: [direct folder, ..., root collection]
+      // If folder == collection (or collection is null), just one row as root
+      const rows: { id: string; name: string; parent_id: string | null; auth_type: string | null; auth_config: string | null; ssl_verification: string | null; integration_id: string | null }[] = []
+      if (collection && collection.id !== folder.id) {
+        rows.push({
+          id: String(folder.id ?? 'f1'),
+          name: String(folder.name ?? 'Folder'),
+          parent_id: String(collection.id ?? 'c1'),
+          auth_type: (folder.auth_type as string | null) ?? null,
+          auth_config: (folder.auth_config as string | null) ?? null,
+          ssl_verification: (folder.ssl_verification as string | null) ?? null,
+          integration_id: null,
+        })
+        rows.push({
+          id: String(collection.id ?? 'c1'),
+          name: String(collection.name ?? 'Collection'),
+          parent_id: null,
+          auth_type: (collection.auth_type as string | null) ?? null,
+          auth_config: (collection.auth_config as string | null) ?? null,
+          ssl_verification: (collection.ssl_verification as string | null) ?? null,
+          integration_id: (collection.integration_id as string | null) ?? null,
+        })
+      } else {
+        rows.push({
+          id: String(folder.id ?? 'c1'),
+          name: String(folder.name ?? 'Collection'),
+          parent_id: null,
+          auth_type: ((folder.auth_type ?? collection?.auth_type) as string | null) ?? null,
+          auth_config: ((folder.auth_config ?? collection?.auth_config) as string | null) ?? null,
+          ssl_verification: ((folder.ssl_verification ?? collection?.ssl_verification) as string | null) ?? null,
+          integration_id: (collection?.integration_id as string | null) ?? null,
+        })
+      }
+      return rows
+    }
     return []
   })
 }
@@ -87,7 +122,9 @@ async function invoke(req: unknown): Promise<Result> {
 }
 
 async function invokeCancel(): Promise<void> {
-  await state.handlers['postly:http:cancel']!(null, null as never)
+  const cancelHandler = state.handlers['postly:http:cancel']
+  if (!cancelHandler) throw new Error('postly:http:cancel handler not registered')
+  await cancelHandler(null, null as never)
 }
 
 /** Asserts the invocation succeeded and returns the data object (never null). */
@@ -175,30 +212,30 @@ describe('http IPC handler', () => {
       expect(data.logs).toContainEqual(expect.objectContaining({ message: 'Auth: bearer' }))
     })
 
-    it('inherits bearer auth from the group when request is "inherit"', async () => {
+    it('inherits bearer auth from the folder when request is "inherit"', async () => {
       setupDb({
-        group: {
-          id: 'g1', name: 'My Group', auth_type: 'bearer',
-          auth_config: '{"token":"grp-tok"}', collection_id: null
+        folder: {
+          id: 'f1', name: 'My Folder', auth_type: 'bearer',
+          auth_config: '{"token":"grp-tok"}', parent_id: null
         }
       })
-      const data = await invokeOk(baseReq({ authType: 'inherit', groupId: 'g1' }))
+      const data = await invokeOk(baseReq({ authType: 'inherit', folderId: 'f1' }))
       expect(data.logs).toContainEqual(expect.objectContaining({
-        message: 'Auth: bearer (inherited from group "My Group")'
+        message: 'Auth: bearer (inherited from folder "My Folder")'
       }))
       const [calledReq] = mockExec.mock.calls[0]
       expect(calledReq.authConfig.token).toBe('grp-tok')
     })
 
-    it('inherits auth from collection when group has no auth', async () => {
+    it('inherits auth from collection when folder has no auth', async () => {
       setupDb({
-        group: { id: 'g1', name: 'G', auth_type: 'inherit', collection_id: 'c1' },
+        folder: { id: 'f1', name: 'F', auth_type: 'inherit', parent_id: 'c1' },
         collection: {
           id: 'c1', name: 'My API', auth_type: 'bearer',
           auth_config: '{"token":"col-tok"}', integration_id: null
         }
       })
-      const data = await invokeOk(baseReq({ authType: 'inherit', groupId: 'g1' }))
+      const data = await invokeOk(baseReq({ authType: 'inherit', folderId: 'f1' }))
       expect(data.logs).toContainEqual(expect.objectContaining({
         message: 'Auth: bearer (inherited from collection "My API")'
       }))
@@ -208,11 +245,11 @@ describe('http IPC handler', () => {
 
     it('uses integration bearer token when collection has an integration', async () => {
       setupDb({
-        group: { id: 'g1', name: 'G', auth_type: null, collection_id: 'c1' },
+        folder: { id: 'f1', name: 'F', auth_type: null, parent_id: 'c1' },
         collection: { id: 'c1', name: 'Coll', auth_type: null, integration_id: 'i1' },
         integration: { id: 'i1', name: 'GitHub', token: 'int-tok' }
       })
-      const data = await invokeOk(baseReq({ authType: 'inherit', groupId: 'g1' }))
+      const data = await invokeOk(baseReq({ authType: 'inherit', folderId: 'f1' }))
       expect(data.logs).toContainEqual(expect.objectContaining({
         message: 'Auth: bearer (inherited from integration "GitHub")'
       }))
@@ -221,8 +258,8 @@ describe('http IPC handler', () => {
     })
 
     it('falls back to "Auth: none" when full inherit chain has no auth', async () => {
-      setupDb({ group: { id: 'g1', name: 'G', auth_type: null, collection_id: null } })
-      const data = await invokeOk(baseReq({ authType: 'inherit', groupId: 'g1' }))
+      setupDb({ folder: { id: 'f1', name: 'F', auth_type: null, parent_id: null } })
+      const data = await invokeOk(baseReq({ authType: 'inherit', folderId: 'f1' }))
       expect(data.logs).toContainEqual(expect.objectContaining({ message: 'Auth: none' }))
     })
   })

--- a/src/main/ipc/__tests__/http.test.ts
+++ b/src/main/ipc/__tests__/http.test.ts
@@ -118,7 +118,9 @@ function baseResp() {
 }
 
 async function invoke(req: unknown): Promise<Result> {
-  return state.handlers['postly:http:execute']!(null, req) as Promise<Result>   // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  const handler = state.handlers['postly:http:execute']
+  if (!handler) throw new Error('postly:http:execute handler not registered')
+  return handler(null, req) as Promise<Result>
 }
 
 async function invokeCancel(): Promise<void> {

--- a/src/main/ipc/__tests__/http.test.ts
+++ b/src/main/ipc/__tests__/http.test.ts
@@ -245,6 +245,146 @@ describe('http IPC handler', () => {
       expect(calledReq.authConfig.token).toBe('col-tok')
     })
 
+    it('inherits auth from the nearest non-inherit ancestor in a 3-level lineage', async () => {
+      const lineage = [
+        {
+          id: 'leaf-1',
+          name: 'Leaf Folder',
+          parent_id: 'mid-1',
+          auth_type: 'inherit',
+          auth_config: null,
+          ssl_verification: null,
+          integration_id: null,
+        },
+        {
+          id: 'mid-1',
+          name: 'Intermediate Folder',
+          parent_id: 'root-1',
+          auth_type: 'bearer',
+          auth_config: '{"token":"mid-tok"}',
+          ssl_verification: null,
+          integration_id: null,
+        },
+        {
+          id: 'root-1',
+          name: 'Root Collection',
+          parent_id: null,
+          auth_type: 'basic',
+          auth_config: '{"username":"root","password":"secret"}',
+          ssl_verification: null,
+          integration_id: null,
+        },
+      ]
+
+      mockQA.mockImplementation((sql: string) => {
+        if (sql.includes('env_vars')) return []
+        if (sql.includes('WITH RECURSIVE lineage')) return lineage
+        return []
+      })
+
+      const data = await invokeOk(baseReq({ authType: 'inherit', folderId: 'leaf-1' }))
+      expect(data.logs).toContainEqual(expect.objectContaining({
+        message: 'Auth: bearer (inherited from folder "Intermediate Folder")'
+      }))
+      const [calledReq] = mockExec.mock.calls[0]
+      expect(calledReq.authType).toBe('bearer')
+      expect(calledReq.authConfig.token).toBe('mid-tok')
+    })
+
+    it('uses the nearest non-inherit SSL setting from an intermediate folder in a 3-level lineage', async () => {
+      const lineage = [
+        {
+          id: 'leaf-1',
+          name: 'Leaf Folder',
+          parent_id: 'mid-1',
+          auth_type: null,
+          auth_config: null,
+          ssl_verification: 'inherit',
+          integration_id: null,
+        },
+        {
+          id: 'mid-1',
+          name: 'Intermediate Folder',
+          parent_id: 'root-1',
+          auth_type: null,
+          auth_config: null,
+          ssl_verification: 'disabled',
+          integration_id: null,
+        },
+        {
+          id: 'root-1',
+          name: 'Root Collection',
+          parent_id: null,
+          auth_type: null,
+          auth_config: null,
+          ssl_verification: 'enabled',
+          integration_id: null,
+        },
+      ]
+
+      mockQA.mockImplementation((sql: string) => {
+        if (sql.includes('env_vars')) return []
+        if (sql.includes('WITH RECURSIVE lineage')) return lineage
+        return []
+      })
+
+      const data = await invokeOk(baseReq({ folderId: 'leaf-1', sslVerification: 'inherit' }))
+      expect(mockExec).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ sslVerification: false })
+      )
+      expect(data.logs).toContainEqual(expect.objectContaining({
+        level: 'warn',
+        message: 'SSL verification disabled (folder "Intermediate Folder")'
+      }))
+    })
+
+    it('labels an intermediate inherited auth source as a folder, not a collection', async () => {
+      const lineage = [
+        {
+          id: 'leaf-1',
+          name: 'Leaf Folder',
+          parent_id: 'mid-1',
+          auth_type: 'inherit',
+          auth_config: null,
+          ssl_verification: null,
+          integration_id: null,
+        },
+        {
+          id: 'mid-1',
+          name: 'Intermediate Folder',
+          parent_id: 'root-1',
+          auth_type: 'bearer',
+          auth_config: '{"token":"mid-tok"}',
+          ssl_verification: null,
+          integration_id: null,
+        },
+        {
+          id: 'root-1',
+          name: 'Root Collection',
+          parent_id: null,
+          auth_type: 'basic',
+          auth_config: '{"username":"root","password":"secret"}',
+          ssl_verification: null,
+          integration_id: null,
+        },
+      ]
+
+      mockQA.mockImplementation((sql: string) => {
+        if (sql.includes('env_vars')) return []
+        if (sql.includes('WITH RECURSIVE lineage')) return lineage
+        return []
+      })
+
+      const data = await invokeOk(baseReq({ authType: 'inherit', folderId: 'leaf-1' }))
+      expect(data.logs).toContainEqual(expect.objectContaining({
+        message: 'Auth: bearer (inherited from folder "Intermediate Folder")'
+      }))
+      expect(data.logs).not.toContainEqual(expect.objectContaining({
+        message: 'Auth: bearer (inherited from collection "Intermediate Folder")'
+      }))
+    })
+
     it('uses integration bearer token when collection has an integration', async () => {
       setupDb({
         folder: { id: 'f1', name: 'F', auth_type: null, parent_id: 'c1' },

--- a/src/main/ipc/__tests__/requests.test.ts
+++ b/src/main/ipc/__tests__/requests.test.ts
@@ -49,6 +49,37 @@ describe('postly:requests:list', () => {
   })
 })
 
+describe('postly:requests:list-all', () => {
+  it('returns all requests ordered by sort_order with no folder filter', async () => {
+    const requests = [
+      { id: 'r1', folder_id: 'f1', sort_order: 0, name: 'Get Users' },
+      { id: 'r2', folder_id: 'f2', sort_order: 1, name: 'Get Health' },
+    ]
+    mockQueryAll.mockReturnValueOnce(requests)
+
+    const result = await handlers['postly:requests:list-all'](null, undefined) as { data: unknown }
+    expect(result.data).toEqual(requests)
+
+    const [sql, params] = mockQueryAll.mock.calls[0] as [string, unknown[] | undefined]
+    expect(sql).toBe('SELECT * FROM requests ORDER BY sort_order ASC')
+    expect(params).toBeUndefined()
+  })
+
+  it('returns an empty array when no requests exist', async () => {
+    mockQueryAll.mockReturnValueOnce([])
+
+    const result = await handlers['postly:requests:list-all'](null, undefined) as { data: unknown[] }
+    expect(result.data).toEqual([])
+  })
+
+  it('wraps database errors', async () => {
+    mockQueryAll.mockImplementationOnce(() => { throw new Error('db error') })
+
+    const result = await handlers['postly:requests:list-all'](null, undefined) as { error: string }
+    expect(result.error).toContain('db error')
+  })
+})
+
 describe('postly:requests:get', () => {
   it('returns a single request by id', async () => {
     const req = { id: 'r1', name: 'Get Users' }

--- a/src/main/ipc/__tests__/requests.test.ts
+++ b/src/main/ipc/__tests__/requests.test.ts
@@ -28,30 +28,26 @@ beforeEach(() => {
   registerRequestHandlers()
 })
 
-// ── list ──────────────────────────────────────────────────────────────────────
-
 describe('postly:requests:list', () => {
-  it('returns requests for a group ordered by sort_order', async () => {
-    const requests = [{ id: 'r1', group_id: 'g1', name: 'Get Users' }]
+  it('returns requests for a folder ordered by sort_order', async () => {
+    const requests = [{ id: 'r1', folder_id: 'f1', name: 'Get Users' }]
     mockQueryAll.mockReturnValueOnce(requests)
 
-    const result = await handlers['postly:requests:list'](null, { groupId: 'g1' }) as { data: unknown }
+    const result = await handlers['postly:requests:list'](null, { folderId: 'f1' }) as { data: unknown }
     expect(result.data).toEqual(requests)
 
     const [sql, params] = mockQueryAll.mock.calls[0] as [string, unknown[]]
-    expect(sql).toContain('WHERE group_id = ?')
-    expect(params).toContain('g1')
+    expect(sql).toContain('WHERE folder_id = ?')
+    expect(params).toContain('f1')
   })
 
   it('returns error string on db failure', async () => {
     mockQueryAll.mockImplementationOnce(() => { throw new Error('db error') })
 
-    const result = await handlers['postly:requests:list'](null, { groupId: 'g1' }) as { error: string }
+    const result = await handlers['postly:requests:list'](null, { folderId: 'f1' }) as { error: string }
     expect(result.error).toContain('db error')
   })
 })
-
-// ── get ───────────────────────────────────────────────────────────────────────
 
 describe('postly:requests:get', () => {
   it('returns a single request by id', async () => {
@@ -71,26 +67,24 @@ describe('postly:requests:get', () => {
   })
 })
 
-// ── create ────────────────────────────────────────────────────────────────────
-
 describe('postly:requests:create', () => {
   it('inserts a row and returns the new request', async () => {
-    const created = { id: 'new-id', group_id: 'g1', name: 'New Request', method: 'GET' }
+    const created = { id: 'new-id', folder_id: 'f1', name: 'New Request', method: 'GET' }
     mockQueryOne.mockReturnValueOnce(created)
 
-    const result = await handlers['postly:requests:create'](null, { groupId: 'g1' }) as { data: unknown }
+    const result = await handlers['postly:requests:create'](null, { folderId: 'f1' }) as { data: unknown }
     expect(result.data).toEqual(created)
     expect(mockRun).toHaveBeenCalledOnce()
 
     const [sql, params] = mockRun.mock.calls[0] as [string, unknown[]]
     expect(sql).toContain('INSERT INTO requests')
-    expect(params).toContain('g1')
+    expect(params).toContain('f1')
   })
 
   it('uses provided name and method', async () => {
     mockQueryOne.mockReturnValueOnce({ id: 'x' })
 
-    await handlers['postly:requests:create'](null, { groupId: 'g1', name: 'My Request', method: 'POST' })
+    await handlers['postly:requests:create'](null, { folderId: 'f1', name: 'My Request', method: 'POST' })
 
     const [, params] = mockRun.mock.calls[0] as [string, unknown[]]
     expect(params).toContain('My Request')
@@ -100,7 +94,7 @@ describe('postly:requests:create', () => {
   it('defaults to name "New Request" and method "GET" when omitted', async () => {
     mockQueryOne.mockReturnValueOnce({ id: 'x' })
 
-    await handlers['postly:requests:create'](null, { groupId: 'g1' })
+    await handlers['postly:requests:create'](null, { folderId: 'f1' })
 
     const [, params] = mockRun.mock.calls[0] as [string, unknown[]]
     expect(params).toContain('New Request')
@@ -110,12 +104,10 @@ describe('postly:requests:create', () => {
   it('returns error string on db failure', async () => {
     mockRun.mockImplementationOnce(() => { throw new Error('constraint') })
 
-    const result = await handlers['postly:requests:create'](null, { groupId: 'g1' }) as { error: string }
+    const result = await handlers['postly:requests:create'](null, { folderId: 'f1' }) as { error: string }
     expect(result.error).toContain('constraint')
   })
 })
-
-// ── update ────────────────────────────────────────────────────────────────────
 
 describe('postly:requests:update', () => {
   it('updates mapped fields and sets updated_at', async () => {
@@ -148,6 +140,13 @@ describe('postly:requests:update', () => {
     expect(sql).toContain('auth_config = ?')
   })
 
+  it('maps folderId to folder_id', async () => {
+    await handlers['postly:requests:update'](null, { id: 'r1', folderId: 'f2' })
+
+    const [sql] = mockRun.mock.calls[0] as [string, unknown[]]
+    expect(sql).toContain('folder_id = ?')
+  })
+
   it('returns data:true with no db call when no fields provided', async () => {
     const result = await handlers['postly:requests:update'](null, { id: 'r1' }) as { data: unknown }
     expect(result.data).toBe(true)
@@ -161,8 +160,6 @@ describe('postly:requests:update', () => {
     expect(result.error).toContain('lock')
   })
 })
-
-// ── delete ────────────────────────────────────────────────────────────────────
 
 describe('postly:requests:delete', () => {
   it('deletes the request by id', async () => {
@@ -181,8 +178,6 @@ describe('postly:requests:delete', () => {
     expect(result.error).toContain('fk')
   })
 })
-
-// ── mark-dirty ────────────────────────────────────────────────────────────────
 
 describe('postly:requests:mark-dirty', () => {
   it('sets is_dirty=1 when isDirty=true', async () => {

--- a/src/main/ipc/collections.ts
+++ b/src/main/ipc/collections.ts
@@ -155,7 +155,7 @@ export function registerCollectionHandlers(): void {
 
   const handleReorder = async (_: unknown, args: {
     type: 'request' | 'folder' | 'group'
-    updates: Array<{ id: string; sortOrder: number; newParentId?: string }>
+    updates: Array<{ id: string; sortOrder: number; newParentId?: string | null }>
   }) => {
     try {
       const now = Date.now()

--- a/src/main/ipc/collections.ts
+++ b/src/main/ipc/collections.ts
@@ -3,8 +3,9 @@ import crypto from 'crypto'
 import { queryAll, queryOne, run } from '../database'
 import * as gitLocal from '../services/git-local'
 
-interface CollectionRow {
+interface FolderRow {
   id: string
+  parent_id: string | null
   name: string
   source: string
   source_meta: string | null
@@ -17,180 +18,236 @@ interface IntegrationRow {
   branch: string | null
 }
 
-export function registerCollectionHandlers(): void {
-  ipcMain.handle('postly:collections:list', async () => {
-    try {
-      const collections = queryAll('SELECT * FROM collections ORDER BY created_at ASC')
-      const groups = queryAll('SELECT * FROM groups ORDER BY sort_order ASC')
-      return { data: { collections, groups } }
-    } catch (err) {
-      return { error: String(err) }
-    }
-  })
+interface FolderCreateArgs {
+  parentId?: string
+  name: string
+  source?: string
+  integrationId?: string
+}
 
-  ipcMain.handle('postly:collections:create', async (_, args: { name: string; source?: string; integrationId?: string }) => {
+interface FolderUpdateArgs {
+  id: string
+  name?: string
+  description?: string
+  authType?: string
+  authConfig?: Record<string, string>
+  sslVerification?: string
+  collapsed?: boolean
+  parentId?: string | null
+  sortOrder?: number
+  hidden?: boolean
+  source?: string
+  sourceMeta?: Record<string, string>
+  integrationId?: string | null
+}
+
+function listFolders() {
+  return queryAll('SELECT * FROM folders ORDER BY sort_order ASC, created_at ASC')
+}
+
+function createFolder(args: FolderCreateArgs) {
+  const id = crypto.randomUUID()
+  const now = Date.now()
+  run(
+    `INSERT INTO folders
+      (id, parent_id, name, source, source_meta, integration_id, auth_type, auth_config,
+       ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, NULL, ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
+    [id, args.parentId ?? null, args.name, args.source ?? 'local', args.integrationId ?? null, now, now]
+  )
+  return queryOne('SELECT * FROM folders WHERE id = ?', [id])
+}
+
+async function deleteFolder(args: { id: string; commitMessage?: string }) {
+  const folder = queryOne<FolderRow>('SELECT * FROM folders WHERE id = ?', [args.id])
+  if (!folder) return true
+
+  if (!folder.parent_id && ['git', 'github', 'gitlab'].includes(folder.source) && folder.integration_id) {
     try {
-      const id = crypto.randomUUID()
-      const now = Date.now()
-      const source = args.source ?? 'local'
-      run(
-        'INSERT INTO collections (id, name, source, integration_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
-        [id, args.name, source, args.integrationId ?? null, now, now]
+      let meta: { fileName?: string } = {}
+      try { meta = JSON.parse(folder.source_meta ?? '{}') } catch { /* ignore */ }
+      const integration = queryOne<IntegrationRow>(
+        'SELECT id, repo, branch FROM integrations WHERE id = ?',
+        [folder.integration_id]
       )
-      return { data: queryOne('SELECT * FROM collections WHERE id = ?', [id]) }
-    } catch (err) {
-      return { error: String(err) }
-    }
-  })
-
-  ipcMain.handle('postly:collections:delete', async (_, args: { id: string; commitMessage?: string }) => {
-    try {
-      const collection = queryOne<CollectionRow>('SELECT * FROM collections WHERE id = ?', [args.id])
-      if (collection?.source === 'git' && collection.integration_id) {
-        try {
-          let meta: { fileName?: string } = {}
-          try { meta = JSON.parse(collection.source_meta ?? '{}') } catch { /* ignore */ }
-          const integration = queryOne<IntegrationRow>(
-            'SELECT id, repo, branch FROM integrations WHERE id = ?',
-            [collection.integration_id]
-          )
-          if (integration && meta.fileName) {
-            await gitLocal.deleteCollectionFile(
-              integration.id,
-              meta.fileName,
-              integration.branch ?? 'main',
-              args.commitMessage ?? `Remove collection: ${collection.name}`
-            )
-          }
-        } catch { /* git failure should not block DB deletion */ }
-      }
-      run('DELETE FROM collections WHERE id = ?', [args.id])
-      return { data: true }
-    } catch (err) {
-      return { error: String(err) }
-    }
-  })
-
-  ipcMain.handle('postly:collections:rename', async (_, args: { id: string; name: string }) => {
-    try {
-      run('UPDATE collections SET name = ?, updated_at = ? WHERE id = ?', [args.name, Date.now(), args.id])
-      return { data: true }
-    } catch (err) {
-      return { error: String(err) }
-    }
-  })
-
-  ipcMain.handle(
-    'postly:collections:update',
-    async (_, args: { id: string; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sslVerification?: string; collapsed?: boolean }) => {
-      try {
-        const fields: string[] = []
-        const values: unknown[] = []
-
-        if (args.name !== undefined) { fields.push('name = ?'); values.push(args.name) }
-        if (args.description !== undefined) { fields.push('description = ?'); values.push(args.description) }
-        if (args.authType !== undefined) { fields.push('auth_type = ?'); values.push(args.authType) }
-        if (args.authConfig !== undefined) { fields.push('auth_config = ?'); values.push(JSON.stringify(args.authConfig)) }
-        if (args.sslVerification !== undefined) { fields.push('ssl_verification = ?'); values.push(args.sslVerification) }
-        if (args.collapsed !== undefined) { fields.push('collapsed = ?'); values.push(args.collapsed ? 1 : 0) }
-        if (fields.length === 0) return { data: true }
-
-        fields.push('updated_at = ?')
-        values.push(Date.now(), args.id)
-
-        run(`UPDATE collections SET ${fields.join(', ')} WHERE id = ?`, values)
-        return { data: true }
-      } catch (err) {
-        return { error: String(err) }
-      }
-    }
-  )
-
-  ipcMain.handle(
-    'postly:groups:create',
-    async (_, args: { collectionId: string; name: string; description?: string }) => {
-      try {
-        const id = crypto.randomUUID()
-        const now = Date.now()
-        run(
-          `INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 0, 0, 0, ?, ?)`,
-          [id, args.collectionId, args.name, args.description ?? null, now, now]
+      if (integration && meta.fileName) {
+        await gitLocal.deleteCollectionFile(
+          integration.id,
+          meta.fileName,
+          integration.branch ?? 'main',
+          args.commitMessage ?? `Remove collection: ${folder.name}`
         )
-        return { data: queryOne('SELECT * FROM groups WHERE id = ?', [id]) }
-      } catch (err) {
-        return { error: String(err) }
       }
+    } catch {
+      /* git failure should not block DB deletion */
     }
-  )
+  }
 
-  ipcMain.handle('postly:groups:delete', async (_, args: { id: string }) => {
+  run('DELETE FROM folders WHERE id = ?', [args.id])
+  return true
+}
+
+function updateFolder(args: FolderUpdateArgs) {
+  const fields: string[] = []
+  const values: unknown[] = []
+
+  if (args.name !== undefined) { fields.push('name = ?'); values.push(args.name) }
+  if (args.description !== undefined) { fields.push('description = ?'); values.push(args.description) }
+  if (args.authType !== undefined) { fields.push('auth_type = ?'); values.push(args.authType) }
+  if (args.authConfig !== undefined) { fields.push('auth_config = ?'); values.push(JSON.stringify(args.authConfig)) }
+  if (args.sslVerification !== undefined) { fields.push('ssl_verification = ?'); values.push(args.sslVerification) }
+  if (args.collapsed !== undefined) { fields.push('collapsed = ?'); values.push(args.collapsed ? 1 : 0) }
+  if (args.parentId !== undefined) { fields.push('parent_id = ?'); values.push(args.parentId ?? null) }
+  if (args.sortOrder !== undefined) { fields.push('sort_order = ?'); values.push(args.sortOrder) }
+  if (args.hidden !== undefined) { fields.push('hidden = ?'); values.push(args.hidden ? 1 : 0) }
+  if (args.source !== undefined) { fields.push('source = ?'); values.push(args.source) }
+  if (args.sourceMeta !== undefined) { fields.push('source_meta = ?'); values.push(JSON.stringify(args.sourceMeta)) }
+  if (args.integrationId !== undefined) { fields.push('integration_id = ?'); values.push(args.integrationId ?? null) }
+  if (fields.length === 0) return true
+
+  fields.push('updated_at = ?')
+  values.push(Date.now(), args.id)
+  run(`UPDATE folders SET ${fields.join(', ')} WHERE id = ?`, values)
+  return true
+}
+
+export function registerCollectionHandlers(): void {
+  const handleList = async () => {
     try {
-      run('DELETE FROM groups WHERE id = ?', [args.id])
+      return { data: listFolders() }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  }
+
+  const handleCreate = async (_: unknown, args: FolderCreateArgs) => {
+    try {
+      return { data: createFolder(args) }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  }
+
+  const handleDelete = async (_: unknown, args: { id: string; commitMessage?: string }) => {
+    try {
+      return { data: await deleteFolder(args) }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  }
+
+  const handleRename = async (_: unknown, args: { id: string; name: string }) => {
+    try {
+      run('UPDATE folders SET name = ?, updated_at = ? WHERE id = ?', [args.name, Date.now(), args.id])
       return { data: true }
     } catch (err) {
       return { error: String(err) }
     }
-  })
+  }
 
-  ipcMain.handle(
-    'postly:groups:update',
-    async (_, args: { id: string; collapsed?: boolean; hidden?: boolean; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sslVerification?: string; sortOrder?: number; collectionId?: string }) => {
-      try {
-        const fields: string[] = []
-        const values: unknown[] = []
-
-        if (args.name !== undefined) { fields.push('name = ?'); values.push(args.name) }
-        if (args.collapsed !== undefined) { fields.push('collapsed = ?'); values.push(args.collapsed ? 1 : 0) }
-        if (args.hidden !== undefined) { fields.push('hidden = ?'); values.push(args.hidden ? 1 : 0) }
-        if (args.description !== undefined) { fields.push('description = ?'); values.push(args.description) }
-        if (args.authType !== undefined) { fields.push('auth_type = ?'); values.push(args.authType) }
-        if (args.authConfig !== undefined) { fields.push('auth_config = ?'); values.push(JSON.stringify(args.authConfig)) }
-        if (args.sslVerification !== undefined) { fields.push('ssl_verification = ?'); values.push(args.sslVerification) }
-        if (args.sortOrder !== undefined) { fields.push('sort_order = ?'); values.push(args.sortOrder) }
-        if (args.collectionId !== undefined) { fields.push('collection_id = ?'); values.push(args.collectionId) }
-        if (fields.length === 0) return { data: true }
-
-        fields.push('updated_at = ?')
-        values.push(Date.now(), args.id)
-
-        run(`UPDATE groups SET ${fields.join(', ')} WHERE id = ?`, values)
-        return { data: true }
-      } catch (err) {
-        return { error: String(err) }
-      }
+  const handleUpdate = async (_: unknown, args: FolderUpdateArgs) => {
+    try {
+      return { data: updateFolder(args) }
+    } catch (err) {
+      return { error: String(err) }
     }
-  )
+  }
 
-  ipcMain.handle('postly:reorder', async (_, args: {
-    type: 'request' | 'group'
+  const handleReorder = async (_: unknown, args: {
+    type: 'request' | 'folder' | 'group'
     updates: Array<{ id: string; sortOrder: number; newParentId?: string }>
   }) => {
     try {
       const now = Date.now()
-      for (const u of args.updates) {
+      for (const update of args.updates) {
         if (args.type === 'request') {
           const fields = ['sort_order = ?', 'updated_at = ?']
-          const vals: unknown[] = [u.sortOrder, now]
-          if (u.newParentId !== undefined) { fields.unshift('group_id = ?'); vals.unshift(u.newParentId) }
-          run(`UPDATE requests SET ${fields.join(', ')} WHERE id = ?`, [...vals, u.id])
+          const values: unknown[] = [update.sortOrder, now]
+          if (update.newParentId !== undefined) {
+            fields.unshift('folder_id = ?')
+            values.unshift(update.newParentId)
+          }
+          run(`UPDATE requests SET ${fields.join(', ')} WHERE id = ?`, [...values, update.id])
         } else {
           const fields = ['sort_order = ?', 'updated_at = ?']
-          const vals: unknown[] = [u.sortOrder, now]
-          if (u.newParentId !== undefined) { fields.unshift('collection_id = ?'); vals.unshift(u.newParentId) }
-          run(`UPDATE groups SET ${fields.join(', ')} WHERE id = ?`, [...vals, u.id])
+          const values: unknown[] = [update.sortOrder, now]
+          if (update.newParentId !== undefined) {
+            fields.unshift('parent_id = ?')
+            values.unshift(update.newParentId)
+          }
+          run(`UPDATE folders SET ${fields.join(', ')} WHERE id = ?`, [...values, update.id])
         }
       }
       return { data: true }
     } catch (err) {
       return { error: String(err) }
     }
-  })
+  }
 
-  ipcMain.handle('postly:collections:move-source', async (_, args: { id: string; source: string }) => {
+  const handleMoveSource = async (_: unknown, args: { id: string; source: string }) => {
     try {
-      run('UPDATE collections SET source = ?, updated_at = ? WHERE id = ?', [args.source, Date.now(), args.id])
+      run('UPDATE folders SET source = ?, updated_at = ? WHERE id = ?', [args.source, Date.now(), args.id])
       return { data: true }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  }
+
+  ipcMain.handle('postly:folders:list', handleList)
+  ipcMain.handle('postly:folders:create', handleCreate)
+  ipcMain.handle('postly:folders:delete', handleDelete)
+  ipcMain.handle('postly:folders:rename', handleRename)
+  ipcMain.handle('postly:folders:update', handleUpdate)
+  ipcMain.handle('postly:folders:move-source', handleMoveSource)
+  ipcMain.handle('postly:reorder', handleReorder)
+
+  ipcMain.handle('postly:collections:list', handleList)
+  ipcMain.handle('postly:collections:create', handleCreate)
+  ipcMain.handle('postly:collections:delete', handleDelete)
+  ipcMain.handle('postly:collections:rename', handleRename)
+  ipcMain.handle('postly:collections:update', handleUpdate)
+  ipcMain.handle('postly:collections:move-source', handleMoveSource)
+
+  ipcMain.handle('postly:groups:create', async (_event, args: { collectionId?: string; parentId?: string; name: string; description?: string }) => {
+    try {
+      return {
+        data: createFolder({
+          parentId: args.parentId ?? args.collectionId,
+          name: args.name,
+          source: 'local',
+        }),
+      }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+  ipcMain.handle('postly:groups:delete', async (_event, args: { id: string }) => {
+    try {
+      return { data: await deleteFolder({ id: args.id }) }
+    } catch (err) {
+      return { error: String(err) }
+    }
+  })
+  ipcMain.handle('postly:groups:update', async (_event, args: {
+    id: string
+    collapsed?: boolean
+    hidden?: boolean
+    name?: string
+    description?: string
+    authType?: string
+    authConfig?: Record<string, string>
+    sslVerification?: string
+    sortOrder?: number
+    collectionId?: string
+    parentId?: string | null
+  }) => {
+    try {
+      return {
+        data: updateFolder({
+          ...args,
+          parentId: args.parentId ?? args.collectionId,
+        }),
+      }
     } catch (err) {
       return { error: String(err) }
     }

--- a/src/main/ipc/export-import.ts
+++ b/src/main/ipc/export-import.ts
@@ -3,8 +3,6 @@ import crypto from 'crypto'
 import fs from 'fs'
 import { queryAll, run } from '../database'
 
-// ─── Schema ────────────────────────────────────────────────────────────────
-
 const SCHEMA = 'postly/v1'
 
 export interface ExportRequest {
@@ -22,22 +20,27 @@ export interface ExportRequest {
   protocolConfig: Record<string, unknown>
 }
 
-export interface ExportGroup {
+export interface ExportFolder {
   name: string
   description: string
   auth: { type: string; config: Record<string, unknown> }
   ssl: string
   requests: ExportRequest[]
+  folders: ExportFolder[]
+  /** @deprecated use folders — present in pre-v2 exports for backward compat */
+  groups?: ExportFolder[]
 }
 
 export interface ExportCollection {
   name: string
   description: string
   source: string
-  integrationName?: string
   auth: { type: string; config: Record<string, unknown> }
   ssl: string
-  groups: ExportGroup[]
+  requests: ExportRequest[]
+  folders: ExportFolder[]
+  /** @deprecated use folders — present in pre-v2 exports for backward compat */
+  groups?: ExportFolder[]
 }
 
 export interface PostlyExportFile {
@@ -46,152 +49,256 @@ export interface PostlyExportFile {
   collections: ExportCollection[]
 }
 
-// ─── Helpers ───────────────────────────────────────────────────────────────
+interface DbFolderRow {
+  id: string
+  parent_id: string | null
+  name: string
+  description: string | null
+  source: string | null
+  auth_type: string | null
+  auth_config: string | null
+  ssl_verification: string | null
+  sort_order: number
+}
+
+interface DbRequestRow {
+  id: string
+  folder_id: string
+  name: string
+  method: string | null
+  url: string | null
+  protocol: string | null
+  params: string | null
+  headers: string | null
+  body_type: string | null
+  body_content: string | null
+  auth_type: string | null
+  auth_config: string | null
+  ssl_verification: string | null
+  description: string | null
+  protocol_config: string | null
+  sort_order: number
+}
 
 export function tryParse<T>(val: unknown, fallback: T): T {
   try { return val ? JSON.parse(String(val)) as T : fallback } catch { return fallback }
 }
 
-// ─── Build export object from DB ───────────────────────────────────────────
+function mapRequest(row: DbRequestRow): ExportRequest {
+  return {
+    name: String(row.name ?? ''),
+    method: String(row.method ?? 'GET'),
+    url: String(row.url ?? ''),
+    protocol: String(row.protocol ?? 'http'),
+    params: tryParse(row.params, []),
+    headers: tryParse(row.headers, []),
+    bodyType: String(row.body_type ?? 'none'),
+    bodyContent: String(row.body_content ?? ''),
+    auth: { type: String(row.auth_type ?? 'none'), config: tryParse(row.auth_config, {}) },
+    ssl: String(row.ssl_verification ?? 'inherit'),
+    description: String(row.description ?? ''),
+    protocolConfig: tryParse(row.protocol_config, {}),
+  }
+}
+
+function mapFolderTree(
+  folder: DbFolderRow,
+  childFolders: Map<string, DbFolderRow[]>,
+  folderRequests: Map<string, DbRequestRow[]>
+): ExportFolder {
+  return {
+    name: String(folder.name ?? ''),
+    description: String(folder.description ?? ''),
+    auth: { type: String(folder.auth_type ?? 'none'), config: tryParse(folder.auth_config, {}) },
+    ssl: String(folder.ssl_verification ?? 'inherit'),
+    requests: (folderRequests.get(folder.id) ?? []).map(mapRequest),
+    folders: (childFolders.get(folder.id) ?? []).map((child) => mapFolderTree(child, childFolders, folderRequests)),
+  }
+}
 
 export function buildExport(collectionIds?: string[]): PostlyExportFile {
-  const rows = collectionIds && collectionIds.length > 0
-    ? queryAll(
-        `SELECT * FROM collections WHERE id IN (${collectionIds.map(() => '?').join(',')}) ORDER BY created_at ASC`,
+  const folderRows = (collectionIds && collectionIds.length > 0
+    ? queryAll<DbFolderRow>(
+        `WITH RECURSIVE tree AS (
+           SELECT * FROM folders WHERE id IN (${collectionIds.map(() => '?').join(',')})
+           UNION ALL
+           SELECT child.*
+           FROM folders child
+           JOIN tree parent ON child.parent_id = parent.id
+         )
+         SELECT * FROM tree ORDER BY sort_order ASC, created_at ASC`,
         collectionIds
       )
-    : queryAll('SELECT * FROM collections ORDER BY created_at ASC')
+    : queryAll<DbFolderRow>('SELECT * FROM folders ORDER BY sort_order ASC, created_at ASC'))
 
-  const collections = (rows as Record<string, unknown>[]).map((col) => {
-    const groupRows = queryAll(
-      'SELECT * FROM groups WHERE collection_id = ? ORDER BY sort_order ASC',
-      [col.id]
-    ) as Record<string, unknown>[]
+  const requestRows = queryAll<DbRequestRow>('SELECT * FROM requests ORDER BY sort_order ASC, created_at ASC')
 
-    const groups: ExportGroup[] = groupRows.map((grp) => {
-      const reqRows = queryAll(
-        'SELECT * FROM requests WHERE group_id = ? ORDER BY sort_order ASC',
-        [grp.id]
-      ) as Record<string, unknown>[]
+  const selectedRootIds = collectionIds ? new Set(collectionIds) : null
+  const folderById = new Map(folderRows.map((row) => [row.id, row]))
+  const childFolders = new Map<string, DbFolderRow[]>()
+  const rootFolders: DbFolderRow[] = []
 
-      const requests: ExportRequest[] = reqRows.map((r) => ({
-        name: String(r.name ?? ''),
-        method: String(r.method ?? 'GET'),
-        url: String(r.url ?? ''),
-        protocol: String(r.protocol ?? 'http'),
-        params: tryParse(r.params, []),
-        headers: tryParse(r.headers, []),
-        bodyType: String(r.body_type ?? 'none'),
-        bodyContent: String(r.body_content ?? ''),
-        auth: { type: String(r.auth_type ?? 'none'), config: tryParse(r.auth_config, {}) },
-        ssl: String(r.ssl_verification ?? 'inherit'),
-        description: String(r.description ?? ''),
-        protocolConfig: tryParse(r.protocol_config, {}),
-      }))
-
-      return {
-        name: String(grp.name ?? ''),
-        description: String(grp.description ?? ''),
-        auth: { type: String(grp.auth_type ?? 'none'), config: tryParse(grp.auth_config, {}) },
-        ssl: String(grp.ssl_verification ?? 'inherit'),
-        requests,
-      }
-    })
-
-    const integrationRow = col.integration_id
-      ? (queryAll('SELECT name FROM integrations WHERE id = ?', [col.integration_id]) as Record<string, unknown>[])[0]
-      : null
-
-    return {
-      name: String(col.name ?? ''),
-      description: String(col.description ?? ''),
-      source: String(col.source ?? 'local'),
-      integrationName: integrationRow ? String(integrationRow.name) : undefined,
-      auth: { type: String(col.auth_type ?? 'none'), config: tryParse(col.auth_config, {}) },
-      ssl: String(col.ssl_verification ?? 'inherit'),
-      groups,
+  for (const folder of folderRows) {
+    if (folder.parent_id && folderById.has(folder.parent_id)) {
+      const siblings = childFolders.get(folder.parent_id) ?? []
+      siblings.push(folder)
+      childFolders.set(folder.parent_id, siblings)
+    } else if (!folder.parent_id) {
+      if (!selectedRootIds || selectedRootIds.has(folder.id)) rootFolders.push(folder)
     }
-  })
+  }
+
+  const exportedIds = new Set<string>()
+  const markExported = (folder: DbFolderRow) => {
+    exportedIds.add(folder.id)
+    for (const child of childFolders.get(folder.id) ?? []) markExported(child)
+  }
+  rootFolders.forEach(markExported)
+
+  const folderRequests = new Map<string, DbRequestRow[]>()
+  for (const request of requestRows) {
+    if (!exportedIds.has(request.folder_id)) continue
+    const rows = folderRequests.get(request.folder_id) ?? []
+    rows.push(request)
+    folderRequests.set(request.folder_id, rows)
+  }
+
+  const collections = rootFolders.map((folder) => ({
+    name: String(folder.name ?? ''),
+    description: String(folder.description ?? ''),
+    source: String(folder.source ?? 'local'),
+    auth: { type: String(folder.auth_type ?? 'none'), config: tryParse(folder.auth_config, {}) },
+    ssl: String(folder.ssl_verification ?? 'inherit'),
+    requests: (folderRequests.get(folder.id) ?? []).map(mapRequest),
+    folders: (childFolders.get(folder.id) ?? []).map((child) => mapFolderTree(child, childFolders, folderRequests)),
+  }))
 
   return { $schema: SCHEMA, exportedAt: new Date().toISOString(), collections }
 }
 
-// ─── Insert imported data into DB ──────────────────────────────────────────
+function importRequests(requests: ExportRequest[], folderId: string, now: number): void {
+  for (const [index, request] of requests.entries()) {
+    const requestId = crypto.randomUUID()
+    run(
+      `INSERT INTO requests
+         (id, folder_id, name, method, url, params, headers, body_type, body_content,
+          auth_type, auth_config, ssl_verification, protocol, protocol_config,
+          description, is_dirty, sort_order, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
+      [
+        requestId,
+        folderId,
+        request.name,
+        request.method ?? 'GET',
+        request.url ?? '',
+        JSON.stringify(request.params ?? []),
+        JSON.stringify(request.headers ?? []),
+        request.bodyType ?? 'none',
+        request.bodyContent ?? '',
+        request.auth?.type ?? 'none',
+        JSON.stringify(request.auth?.config ?? {}),
+        request.ssl ?? 'inherit',
+        request.protocol ?? 'http',
+        JSON.stringify(request.protocolConfig ?? {}),
+        request.description ?? '',
+        index,
+        now,
+        now,
+      ]
+    )
+  }
+}
+
+function importFolder(folder: ExportFolder, parentId: string, sortOrder: number, now: number): void {
+  const folderId = crypto.randomUUID()
+  run(
+    `INSERT INTO folders
+      (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config,
+       ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'local', NULL, NULL, ?, ?, ?, 0, 0, ?, ?, ?)`,
+    [
+      folderId,
+      parentId,
+      folder.name,
+      folder.description ?? '',
+      folder.auth?.type ?? 'none',
+      JSON.stringify(folder.auth?.config ?? {}),
+      folder.ssl ?? 'inherit',
+      sortOrder,
+      now,
+      now,
+    ]
+  )
+  importRequests(folder.requests ?? [], folderId, now)
+  // fall back to `groups` for exports created before the folder-tree refactor
+  const children = folder.folders ?? folder.groups ?? []
+  for (const [index, child] of children.entries()) {
+    importFolder(child, folderId, index, now)
+  }
+}
 
 export function importData(data: PostlyExportFile): number {
   const now = Date.now()
-  for (const col of data.collections) {
-    const colId = crypto.randomUUID()
+  for (const [collectionIndex, collection] of data.collections.entries()) {
+    const collectionId = crypto.randomUUID()
     run(
-      `INSERT INTO collections (id, name, source, description, auth_type, auth_config, ssl_verification, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [colId, col.name, col.source ?? 'local', col.description ?? '', col.auth?.type ?? 'none',
-       JSON.stringify(col.auth?.config ?? {}), col.ssl ?? 'inherit', now, now]
+      `INSERT INTO folders
+        (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config,
+         ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+       VALUES (?, NULL, ?, ?, ?, NULL, NULL, ?, ?, ?, 0, 0, ?, ?, ?)`,
+      [
+        collectionId,
+        collection.name,
+        collection.description ?? '',
+        collection.source ?? 'local',
+        collection.auth?.type ?? 'none',
+        JSON.stringify(collection.auth?.config ?? {}),
+        collection.ssl ?? 'inherit',
+        collectionIndex,
+        now,
+        now,
+      ]
     )
-    for (const [gi, grp] of col.groups.entries()) {
-      const grpId = crypto.randomUUID()
-      run(
-        `INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, auth_type, auth_config, ssl_verification, created_at, updated_at)
-         VALUES (?, ?, ?, ?, 0, 0, ?, ?, ?, ?, ?, ?)`,
-        [grpId, colId, grp.name, grp.description ?? '', gi,
-         grp.auth?.type ?? 'none', JSON.stringify(grp.auth?.config ?? {}),
-         grp.ssl ?? 'inherit', now, now]
-      )
-      for (const [ri, req] of grp.requests.entries()) {
-        const reqId = crypto.randomUUID()
-        run(
-          `INSERT INTO requests
-             (id, group_id, name, method, url, params, headers, body_type, body_content,
-              auth_type, auth_config, ssl_verification, protocol, protocol_config,
-              description, is_dirty, sort_order, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
-          [reqId, grpId, req.name, req.method ?? 'GET', req.url ?? '',
-           JSON.stringify(req.params ?? []), JSON.stringify(req.headers ?? []),
-           req.bodyType ?? 'none', req.bodyContent ?? '',
-           req.auth?.type ?? 'none', JSON.stringify(req.auth?.config ?? {}),
-           req.ssl ?? 'inherit', req.protocol ?? 'http',
-           JSON.stringify(req.protocolConfig ?? {}),
-           req.description ?? '', ri, now, now]
-        )
-      }
+    importRequests(collection.requests ?? [], collectionId, now)
+    // fall back to `groups` for exports created before the folder-tree refactor
+    const topFolders = collection.folders ?? collection.groups ?? []
+    for (const [folderIndex, folder] of topFolders.entries()) {
+      importFolder(folder, collectionId, folderIndex, now)
     }
   }
   return data.collections.length
 }
-
-// ─── IPC handlers ──────────────────────────────────────────────────────────
 
 function winFromEvent(event: Electron.IpcMainInvokeEvent): BrowserWindow | null {
   return BrowserWindow.fromWebContents(event.sender)
 }
 
 export function registerExportImportHandlers(): void {
-  /** Export one or more collections to a .postly.json file via save dialog. */
   ipcMain.handle('postly:export', async (event, args: { collectionIds?: string[] } = {}) => {
     try {
       const win = winFromEvent(event)
       const data = buildExport(args.collectionIds)
       const defaultName = data.collections.length === 1
         ? `${data.collections[0].name.replace(/[^a-z0-9_-]/gi, '_')}.postly.json`
-        : `postly-export.json`
+        : 'postly-export.json'
 
       const result = await (win
         ? dialog.showSaveDialog(win, {
-          title: 'Export Collections',
-          defaultPath: defaultName,
-          filters: [
-            { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
-            { name: 'All Files', extensions: ['*'] },
-          ],
-        })
+            title: 'Export Collections',
+            defaultPath: defaultName,
+            filters: [
+              { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
+          })
         : dialog.showSaveDialog({
-          title: 'Export Collections',
-          defaultPath: defaultName,
-          filters: [
-            { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
-            { name: 'All Files', extensions: ['*'] },
-          ],
-        }))
+            title: 'Export Collections',
+            defaultPath: defaultName,
+            filters: [
+              { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
+          }))
       if (result.canceled || !result.filePath) return { data: null }
 
       fs.writeFileSync(result.filePath, JSON.stringify(data, null, 2), 'utf-8')
@@ -201,27 +308,26 @@ export function registerExportImportHandlers(): void {
     }
   })
 
-  /** Open a .postly.json file via open dialog and import all collections in it. */
   ipcMain.handle('postly:import', async (event) => {
     try {
       const win = winFromEvent(event)
       const result = await (win
         ? dialog.showOpenDialog(win, {
-          title: 'Import Collections',
-          filters: [
-            { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
-            { name: 'All Files', extensions: ['*'] },
-          ],
-          properties: ['openFile'],
-        })
+            title: 'Import Collections',
+            filters: [
+              { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
+            properties: ['openFile'],
+          })
         : dialog.showOpenDialog({
-          title: 'Import Collections',
-          filters: [
-            { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
-            { name: 'All Files', extensions: ['*'] },
-          ],
-          properties: ['openFile'],
-        }))
+            title: 'Import Collections',
+            filters: [
+              { name: 'Postly Collection (*.postly.json)', extensions: ['json'] },
+              { name: 'All Files', extensions: ['*'] },
+            ],
+            properties: ['openFile'],
+          }))
       if (result.canceled || result.filePaths.length === 0) return { data: null }
 
       const raw = fs.readFileSync(result.filePaths[0], 'utf-8')
@@ -238,7 +344,6 @@ export function registerExportImportHandlers(): void {
     }
   })
 
-  /** Import pre-parsed collections sent from the renderer (no file dialog). */
   ipcMain.handle('postly:import:collections', async (_event, args: { collections: ExportCollection[] }) => {
     try {
       if (!Array.isArray(args?.collections)) return { error: 'Invalid collections data.' }

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -16,7 +16,7 @@ interface IntegrationRow {
 
 interface RequestRow {
   id: string
-  group_id: string
+  folder_id: string
   name: string
   method: string
   url: string
@@ -32,16 +32,13 @@ interface RequestRow {
   is_dirty: number
 }
 
-interface GroupRow {
+interface FolderRow {
   id: string
-  collection_id: string
+  parent_id: string | null
   name: string
-}
-
-interface CollectionRow {
-  source_meta: string
   source: string
-  integration_id?: string
+  source_meta: string | null
+  integration_id?: string | null
 }
 
 function getIntegration(id: string): IntegrationRow {
@@ -50,47 +47,85 @@ function getIntegration(id: string): IntegrationRow {
   return row
 }
 
+function getRootFolder(folderId: string): FolderRow | null {
+  return queryOne<FolderRow>(
+    `WITH RECURSIVE lineage AS (
+       SELECT id, parent_id, name, source, source_meta, integration_id FROM folders WHERE id = ?
+       UNION ALL
+       SELECT f.id, f.parent_id, f.name, f.source, f.source_meta, f.integration_id
+       FROM folders f
+       JOIN lineage l ON l.parent_id = f.id
+     )
+     SELECT id, parent_id, name, source, source_meta, integration_id
+     FROM lineage
+     WHERE parent_id IS NULL
+     LIMIT 1`,
+    [folderId]
+  )
+}
+
+function getTreeFolderIds(collectionId: string): string[] {
+  return queryAll<{ id: string }>(
+    `WITH RECURSIVE tree AS (
+       SELECT id FROM folders WHERE id = ?
+       UNION ALL
+       SELECT child.id
+       FROM folders child
+       JOIN tree parent ON child.parent_id = parent.id
+     )
+     SELECT id FROM tree`,
+    [collectionId]
+  ).map((row) => row.id)
+}
+
+function clearDirtyForCollection(collectionId: string): void {
+  run(
+    `WITH RECURSIVE tree AS (
+       SELECT id FROM folders WHERE id = ?
+       UNION ALL
+       SELECT child.id
+       FROM folders child
+       JOIN tree parent ON child.parent_id = parent.id
+     )
+     UPDATE requests
+     SET is_dirty = 0, updated_at = ?
+     WHERE folder_id IN (SELECT id FROM tree)`,
+    [collectionId, Date.now()]
+  )
+}
+
 function getSourceMetaForRequest(requestId: string): {
   source: string
   sourceMeta: Record<string, string>
   integration: IntegrationRow | null
+  collection: FolderRow | null
 } {
   const request = queryOne<RequestRow>('SELECT * FROM requests WHERE id = ?', [requestId])
   if (!request) throw new Error('Request not found')
 
-  const group = queryOne<GroupRow>('SELECT collection_id FROM groups WHERE id = ?', [request.group_id])
-  const collection = group
-    ? queryOne<CollectionRow>('SELECT source, source_meta, integration_id FROM collections WHERE id = ?', [group.collection_id])
-    : undefined
-  const sourceMeta: Record<string, string> = collection?.source_meta
-    ? JSON.parse(collection.source_meta)
-    : {}
+  const collection = getRootFolder(request.folder_id)
+  const sourceMeta: Record<string, string> = collection?.source_meta ? JSON.parse(collection.source_meta) : {}
   const source = collection?.source ?? ''
 
-  // Prefer integration_id stored on collection, then fall back to matching by source type
   const integrationId = collection?.integration_id ?? sourceMeta.integrationId
   const integration = integrationId
     ? queryOne<IntegrationRow>('SELECT * FROM integrations WHERE id = ?', [integrationId])
     : source === 'github' || source === 'gitlab'
-    ? queryOne<IntegrationRow>(
-        `SELECT * FROM integrations WHERE type = ? ORDER BY updated_at DESC LIMIT 1`,
-        [source]
-      )
-    : null
+      ? queryOne<IntegrationRow>(
+          `SELECT * FROM integrations WHERE type = ? ORDER BY updated_at DESC LIMIT 1`,
+          [source]
+        )
+      : null
 
-  return { source, sourceMeta, integration }
+  return { source, sourceMeta, integration, collection }
 }
 
 export function registerGitHandlers(): void {
-  // ── Current branch ────────────────────────────────────────────────────────────
-
   ipcMain.handle('postly:git:current-branch', async (_, args: { integrationId: string }) => {
     try {
       return { data: await gitLocal.getCurrentBranch(args.integrationId) }
     } catch (err) { return { error: String(err) } }
   })
-
-  // ── List branches ────────────────────────────────────────────────────────────
 
   ipcMain.handle('postly:git:branches:list', async (_, args: { integrationId: string }) => {
     try {
@@ -106,8 +141,6 @@ export function registerGitHandlers(): void {
       return { data: [] }
     } catch (err) { return { error: String(err) } }
   })
-
-  // ── Create branch ────────────────────────────────────────────────────────────
 
   ipcMain.handle('postly:git:branch:create', async (_, args: {
     integrationId: string; newBranch: string; fromBranch: string
@@ -126,8 +159,6 @@ export function registerGitHandlers(): void {
     } catch (err) { return { error: String(err) } }
   })
 
-  // ── Switch branch ─────────────────────────────────────────────────────────────
-
   ipcMain.handle('postly:git:branch:switch', async (_, args: { integrationId: string; branch: string }) => {
     try {
       const integration = getIntegration(args.integrationId)
@@ -138,8 +169,6 @@ export function registerGitHandlers(): void {
       return { data: true }
     } catch (err) { return { error: String(err) } }
   })
-
-  // ── Sync / pull ────────────────────────────────────────────────────────────
 
   ipcMain.handle('postly:git:sync', async (_, args: { integrationId: string; collectionId?: string; collectionName?: string }) => {
     try {
@@ -166,8 +195,6 @@ export function registerGitHandlers(): void {
       return { data: true }
     } catch (err) { return { error: String(err) } }
   })
-
-  // ── Diff ──────────────────────────────────────────────────────────────────
 
   ipcMain.handle('postly:git:diff', async (_, args: { requestId: string }) => {
     try {
@@ -198,8 +225,6 @@ export function registerGitHandlers(): void {
     } catch (err) { return { error: String(err) } }
   })
 
-  // ── Commit ─────────────────────────────────────────────────────────────────
-
   ipcMain.handle('postly:git:commit', async (_, args: {
     requestId: string
     commitMessage: string
@@ -210,20 +235,15 @@ export function registerGitHandlers(): void {
       const request = queryOne<RequestRow>('SELECT * FROM requests WHERE id = ?', [args.requestId])
       if (!request) return { error: 'Request not found' }
 
-      const { source, sourceMeta, integration } = getSourceMetaForRequest(args.requestId)
+      const { source, sourceMeta, integration, collection } = getSourceMetaForRequest(args.requestId)
       if (!integration) return { error: 'No integration found for this collection' }
+      if (!collection) return { error: 'Collection not found' }
 
-      // Resolve the collection this request belongs to
-      const group = queryOne<GroupRow>('SELECT id, name, collection_id FROM groups WHERE id = ?', [request.group_id])
-      if (!group) return { error: 'Group not found' }
-      const collectionId = group.collection_id
-
-      // Build the full collection in postly/v1 export format — same as File → Export
+      const collectionId = collection.id
       const exportData = buildExport([collectionId])
       const collectionExport = exportData.collections[0]
       if (!collectionExport) return { error: 'Collection not found' }
 
-      // File is stored as <collection-slug>.postly.json at the repo root
       const slug = (s: string) => s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'collection'
       const scmPath = `${slug(collectionExport.name)}.postly.json`
       const fileContent = JSON.stringify(
@@ -238,17 +258,10 @@ export function registerGitHandlers(): void {
           await gitLocal.createAndPushBranch(integration.id, branch, args.fromBranch)
         }
         await gitLocal.commitAndPush(integration.id, scmPath, fileContent, args.commitMessage, branch)
-        // Clear dirty flag for all requests in this collection
-        run(
-          `UPDATE requests SET is_dirty = 0, updated_at = ? WHERE group_id IN (
-             SELECT id FROM groups WHERE collection_id = ?
-           )`,
-          [Date.now(), collectionId]
-        )
+        clearDirtyForCollection(collectionId)
         return { data: true }
       }
 
-      // Legacy github / gitlab REST API path
       if (args.fromBranch && branch !== args.fromBranch) {
         if (source === 'github') {
           const [owner, ...repoParts] = (sourceMeta.repo ?? integration.repo).split('/')
@@ -274,11 +287,10 @@ export function registerGitHandlers(): void {
       }
 
       run('UPDATE requests SET scm_sha = ?, is_dirty = 0, updated_at = ? WHERE id = ?', [newSha, Date.now(), args.requestId])
+      clearDirtyForCollection(collectionId)
       return { data: true }
     } catch (err) { return { error: String(err) } }
   })
-
-  // ── Import into a specific collection (used during setup) ──────────────────
 
   ipcMain.handle('postly:git:import', async (_, args: {
     integrationId: string
@@ -293,15 +305,13 @@ export function registerGitHandlers(): void {
         collectionName: args.collectionName,
       })
       const collection = queryOne<{ id: string; name: string }>(
-        `SELECT id, name FROM collections WHERE id = ?`,
+        `SELECT id, name FROM folders WHERE id = ?`,
         [collectionId]
       )
       return { data: collection }
     } catch (err) {
-      // discoverAndImport creates the collection before cloning, so it may already
-      // exist even when clone/scan throws. Return it so the UI can still navigate there.
       const collection = queryOne<{ id: string; name: string }>(
-        `SELECT id, name FROM collections WHERE integration_id = ? AND source = 'git'`,
+        `SELECT id, name FROM folders WHERE parent_id IS NULL AND integration_id = ? AND source = 'git'`,
         [args.integrationId]
       )
       if (collection) return { data: collection }
@@ -309,22 +319,20 @@ export function registerGitHandlers(): void {
     }
   })
 
-  // ── List dirty requests for a collection ────────────────────────────────────
-
   ipcMain.handle('postly:git:dirty-requests', async (_, args: { collectionId: string }) => {
     try {
-      const rows = queryAll<RequestRow & { group_name: string; request_name: string }>(
-        `SELECT r.id, r.group_id, r.scm_path, r.name as request_name, g.name as group_name
+      const folderIds = getTreeFolderIds(args.collectionId)
+      if (folderIds.length === 0) return { data: [] }
+      const rows = queryAll<Array<RequestRow & { folder_name: string; group_name: string; request_name: string }> extends never ? never : RequestRow & { folder_name: string; group_name: string; request_name: string }>(
+        `SELECT r.id, r.folder_id, r.scm_path, r.name as request_name, f.name as folder_name, f.name as group_name
          FROM requests r
-         JOIN groups g ON g.id = r.group_id
-         WHERE g.collection_id = ? AND r.is_dirty = 1`,
-        [args.collectionId]
+         JOIN folders f ON f.id = r.folder_id
+         WHERE r.is_dirty = 1 AND r.folder_id IN (${folderIds.map(() => '?').join(',')})`,
+        folderIds
       )
       return { data: rows }
     } catch (err) { return { error: String(err) } }
   })
-
-  // ── Push collection — re-export and commit + push ───────────────────────────
 
   ipcMain.handle('postly:git:push-collection', async (_, args: {
     collectionId: string
@@ -333,7 +341,7 @@ export function registerGitHandlers(): void {
   }) => {
     try {
       const collection = queryOne<{ id: string; name: string; source: string; source_meta: string | null; integration_id: string | null }>(
-        'SELECT id, name, source, source_meta, integration_id FROM collections WHERE id = ?',
+        'SELECT id, name, source, source_meta, integration_id FROM folders WHERE id = ?',
         [args.collectionId]
       )
       if (!collection) return { error: 'Collection not found' }
@@ -357,17 +365,12 @@ export function registerGitHandlers(): void {
 
       await gitLocal.commitAndPush(integration.id, fileName, fileContent, args.commitMessage, args.branch)
 
-      // Persist the fileName in source_meta so future syncs can match
       if (!meta.fileName) {
-        run('UPDATE collections SET source_meta = ?, updated_at = ? WHERE id = ?',
+        run('UPDATE folders SET source_meta = ?, updated_at = ? WHERE id = ?',
           [JSON.stringify({ ...meta, integrationId, fileName }), Date.now(), args.collectionId])
       }
 
-      // Clear dirty flags for all requests in this collection
-      run(`UPDATE requests SET is_dirty = 0, updated_at = ? WHERE group_id IN (
-             SELECT id FROM groups WHERE collection_id = ?
-           )`, [Date.now(), args.collectionId])
-
+      clearDirtyForCollection(args.collectionId)
       return { data: true }
     } catch (err) { return { error: String(err) } }
   })

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -323,7 +323,7 @@ export function registerGitHandlers(): void {
     try {
       const folderIds = getTreeFolderIds(args.collectionId)
       if (folderIds.length === 0) return { data: [] }
-      const rows = queryAll<Array<RequestRow & { folder_name: string; group_name: string; request_name: string }> extends never ? never : RequestRow & { folder_name: string; group_name: string; request_name: string }>(
+      const rows = queryAll<RequestRow & { folder_name: string; group_name: string; request_name: string }>(
         `SELECT r.id, r.folder_id, r.scm_path, r.name as request_name, f.name as folder_name, f.name as group_name
          FROM requests r
          JOIN folders f ON f.id = r.folder_id

--- a/src/main/ipc/github.ts
+++ b/src/main/ipc/github.ts
@@ -17,6 +17,21 @@ function getGitHubSettings(): GitHubSettings {
   return JSON.parse(row.value) as GitHubSettings
 }
 
+function getRootSourceMeta(folderId: string): Record<string, string> {
+  const row = queryOne<{ source_meta: string | null }>(
+    `WITH RECURSIVE lineage AS (
+       SELECT id, parent_id, source_meta FROM folders WHERE id = ?
+       UNION ALL
+       SELECT f.id, f.parent_id, f.source_meta
+       FROM folders f
+       JOIN lineage l ON l.parent_id = f.id
+     )
+     SELECT source_meta FROM lineage WHERE parent_id IS NULL LIMIT 1`,
+    [folderId]
+  )
+  return row?.source_meta ? JSON.parse(row.source_meta) : {}
+}
+
 export function registerGitHubHandlers(): void {
   ipcMain.handle('postly:github:sync', async () => {
     try { await discoverApis(getGitHubSettings()); return { data: true } }
@@ -63,10 +78,7 @@ export function registerGitHubHandlers(): void {
 
       const scmPath = String(request['scm_path'] ?? '')
       const localContent = String(request['body_content'] ?? '')
-
-      const group = queryOne<{ collection_id: string }>('SELECT collection_id FROM groups WHERE id = ?', [String(request['group_id'])])
-      const collection = group ? queryOne<{ source_meta: string }>('SELECT source_meta FROM collections WHERE id = ?', [group.collection_id]) : undefined
-      const sourceMeta = collection?.source_meta ? JSON.parse(collection.source_meta) : {}
+      const sourceMeta = getRootSourceMeta(String(request['folder_id']))
       const [owner, repo] = (sourceMeta.repo ?? '/').split('/')
 
       const remoteContent = await getFileContent(settings.token, owner, repo, scmPath, 'main')

--- a/src/main/ipc/gitlab.ts
+++ b/src/main/ipc/gitlab.ts
@@ -17,6 +17,21 @@ function getGitLabSettings(): GitLabSettings {
   return JSON.parse(row.value) as GitLabSettings
 }
 
+function getRootSourceMeta(folderId: string): Record<string, string> {
+  const row = queryOne<{ source_meta: string | null }>(
+    `WITH RECURSIVE lineage AS (
+       SELECT id, parent_id, source_meta FROM folders WHERE id = ?
+       UNION ALL
+       SELECT f.id, f.parent_id, f.source_meta
+       FROM folders f
+       JOIN lineage l ON l.parent_id = f.id
+     )
+     SELECT source_meta FROM lineage WHERE parent_id IS NULL LIMIT 1`,
+    [folderId]
+  )
+  return row?.source_meta ? JSON.parse(row.source_meta) : {}
+}
+
 export function registerGitLabHandlers(): void {
   ipcMain.handle('postly:gitlab:sync', async () => {
     try { await discoverApis(getGitLabSettings()); return { data: true } }
@@ -62,10 +77,7 @@ export function registerGitLabHandlers(): void {
 
       const scmPath = String(request['scm_path'] ?? '')
       const localContent = String(request['body_content'] ?? '')
-
-      const group = queryOne<{ collection_id: string }>('SELECT collection_id FROM groups WHERE id = ?', [String(request['group_id'])])
-      const collection = group ? queryOne<{ source_meta: string }>('SELECT source_meta FROM collections WHERE id = ?', [group.collection_id]) : undefined
-      const sourceMeta = collection?.source_meta ? JSON.parse(collection.source_meta) : {}
+      const sourceMeta = getRootSourceMeta(String(request['folder_id']))
       const projectId = String(sourceMeta.projectId ?? '')
 
       const remoteContent = await getFileContent(settings.token, settings.baseUrl, projectId, scmPath, 'main')

--- a/src/main/ipc/http.ts
+++ b/src/main/ipc/http.ts
@@ -1,10 +1,20 @@
-import { ipcMain } from 'electron'
+import { ipcMain, type IpcMainInvokeEvent } from 'electron'
 import { queryAll, queryOne } from '../database'
 import { executeRequest, HttpRequest, LogEntry } from '../services/http-executor'
 import { getValidTokenForConfig, authorizeInline } from '../services/oauth'
 import { getGeneralSettings } from './settings-utils'
 
 type LogLevel = 'info' | 'warn' | 'error'
+
+type FolderLineageRow = {
+  id: string
+  name: string
+  parent_id: string | null
+  auth_type: string | null
+  auth_config: string | null
+  ssl_verification: string | null
+  integration_id: string | null
+}
 
 let currentAbortController: AbortController | null = null
 
@@ -37,18 +47,37 @@ function formatExpiry(expiresAt: number | undefined): string {
   return `expires in ${Math.floor(hours / 24)}d`
 }
 
+/** Returns all folders from the given folder up to the root, ordered nearest-first (depth ASC). */
+function getFolderLineage(folderId?: string): FolderLineageRow[] {
+  if (!folderId) return []
+  return queryAll<FolderLineageRow>(
+    `WITH RECURSIVE lineage AS (
+       SELECT id, parent_id, name, auth_type, auth_config, ssl_verification, integration_id, 0 AS depth
+       FROM folders
+       WHERE id = ?
+       UNION ALL
+       SELECT f.id, f.parent_id, f.name, f.auth_type, f.auth_config, f.ssl_verification, f.integration_id, lineage.depth + 1
+       FROM folders f
+       JOIN lineage ON lineage.parent_id = f.id
+     )
+     SELECT id, parent_id, name, auth_type, auth_config, ssl_verification, integration_id
+     FROM lineage
+     ORDER BY depth ASC`,
+    [folderId]
+  )
+}
+
 export function registerHttpHandlers(): void {
   ipcMain.handle('postly:http:cancel', () => {
     currentAbortController?.abort()
     currentAbortController = null
   })
 
-  ipcMain.handle('postly:http:execute', async (_, req: HttpRequest) => {
+  ipcMain.handle('postly:http:execute', async (_: IpcMainInvokeEvent, req: HttpRequest) => {
     const logs: LogEntry[] = []
     const log = (level: LogLevel, message: string, detail?: string) => logs.push({ level, message, detail })
 
     try {
-      // ── Environment ──────────────────────────────────────────────────────────
       const activeEnv = queryOne<{ id: string; name: string }>(
         'SELECT id, name FROM environments WHERE is_active = 1 LIMIT 1'
       )
@@ -65,40 +94,31 @@ export function registerHttpHandlers(): void {
         log('info', 'No active environment')
       }
 
-      // ── Eager group/collection fetch ─────────────────────────────────────────
-      // Fetch once when a groupId is present; reused for both auth and SSL
-      // resolution below to avoid redundant DB round-trips.
-      const groupRow = req.groupId
-        ? queryOne<Record<string, unknown>>('SELECT * FROM groups WHERE id = ?', [req.groupId])
-        : null
-      const collectionRow = groupRow?.collection_id
-        ? queryOne<Record<string, unknown>>('SELECT * FROM collections WHERE id = ?', [groupRow.collection_id])
-        : null
+      const lineage = getFolderLineage(req.folderId)
+      const rootFolder = lineage.find((f) => !f.parent_id)
 
-      // ── Auth resolution ───────────────────────────────────────────────────────
       let resolvedAuthType = req.authType
       let resolvedAuthConfig = req.authConfig
       let authSource = 'request'
 
       const shouldInherit = (t: string) => t === 'inherit' || !t
 
-      if (shouldInherit(resolvedAuthType) && groupRow) {
-        if (groupRow?.auth_type && !shouldInherit(groupRow.auth_type as string)) {
-          resolvedAuthType = groupRow.auth_type as string
-          resolvedAuthConfig = safeParseJSON(groupRow.auth_config as string, {})
-          authSource = `group "${groupRow.name as string}"`
-        } else {
-          if (collectionRow?.auth_type && !shouldInherit(collectionRow.auth_type as string)) {
-            resolvedAuthType = collectionRow.auth_type as string
-            resolvedAuthConfig = safeParseJSON(collectionRow.auth_config as string, {})
-            authSource = `collection "${collectionRow.name as string}"`
-          } else if (collectionRow?.integration_id) {
-            const integration = queryOne<Record<string, unknown>>('SELECT * FROM integrations WHERE id = ?', [collectionRow.integration_id])
-            if (integration?.token) {
-              resolvedAuthType = 'bearer'
-              resolvedAuthConfig = { token: integration.token as string }
-              authSource = `integration "${integration.name as string}"`
-            }
+      if (shouldInherit(resolvedAuthType) && lineage.length > 0) {
+        // Walk up from the direct folder to the root — use the nearest ancestor with explicit auth
+        const inheritedIdx = lineage.findIndex((f) => f.auth_type && !shouldInherit(f.auth_type))
+        const inherited = inheritedIdx >= 0 ? lineage[inheritedIdx] : null
+        if (inherited) {
+          resolvedAuthType = inherited.auth_type ?? 'none'
+          resolvedAuthConfig = safeParseJSON(inherited.auth_config, {})
+          // depth 0 = direct folder of the request; root ancestors (parent_id IS NULL, depth > 0) = "collection"
+          const isDirectFolder = inheritedIdx === 0
+          authSource = (isDirectFolder || inherited.parent_id) ? `folder "${inherited.name}"` : `collection "${inherited.name}"`
+        } else if (rootFolder?.integration_id) {
+          const integration = queryOne<Record<string, unknown>>('SELECT * FROM integrations WHERE id = ?', [rootFolder.integration_id])
+          if (integration?.token) {
+            resolvedAuthType = 'bearer'
+            resolvedAuthConfig = { token: integration.token as string }
+            authSource = `integration "${integration.name as string}"`
           }
         }
       }
@@ -113,23 +133,20 @@ export function registerHttpHandlers(): void {
         log('info', `Auth: ${resolvedAuthType} (inherited from ${authSource})`)
       }
 
-      // ── Settings ─────────────────────────────────────────────────────────────
       const generalSettings = getGeneralSettings()
       let sslVerification = generalSettings.sslVerification
       const followRedirects = generalSettings.followRedirects
       const timeout = generalSettings.defaultTimeout
 
-      // ── SSL resolution ────────────────────────────────────────────────────────
       const shouldInheritSsl = (v: string | undefined) => !v || v === 'inherit'
       let resolvedSsl: string | undefined = req.sslVerification
       let sslSource = 'global setting'
-      if (shouldInheritSsl(resolvedSsl) && groupRow) {
-        if (groupRow?.ssl_verification && !shouldInheritSsl(groupRow.ssl_verification as string)) {
-          resolvedSsl = groupRow.ssl_verification as string
-          sslSource = `group "${groupRow.name as string}"`
-        } else if (collectionRow?.ssl_verification && !shouldInheritSsl(collectionRow.ssl_verification as string)) {
-          resolvedSsl = collectionRow.ssl_verification as string
-          sslSource = `collection "${collectionRow.name as string}"`
+      if (shouldInheritSsl(resolvedSsl) && lineage.length > 0) {
+        // Walk up from the direct folder to the root — use the nearest ancestor with explicit ssl
+        const inheritedSsl = lineage.find((f) => f.ssl_verification && !shouldInheritSsl(f.ssl_verification))
+        if (inheritedSsl) {
+          resolvedSsl = inheritedSsl.ssl_verification ?? undefined
+          sslSource = inheritedSsl.parent_id ? `folder "${inheritedSsl.name}"` : `collection "${inheritedSsl.name}"`
         }
       }
       if (resolvedSsl === 'enabled') sslVerification = true
@@ -138,7 +155,6 @@ export function registerHttpHandlers(): void {
       if (!sslVerification) log('warn', `SSL verification disabled (${sslSource})`)
       if (!followRedirects) log('info', 'Following redirects: disabled')
 
-      // ── OAuth 2.0 token resolution ────────────────────────────────────────────
       if (resolvedAuthType === 'oauth2') {
         const cfg = {
           id: '',
@@ -179,9 +195,8 @@ export function registerHttpHandlers(): void {
         }
       }
 
-      // ── Environment variable interpolation ───────────────────────────────────
       const urlCount = countInterpolations(req.url, envVars)
-      const headerCount = Object.values(req.headers).reduce((s, v) => s + countInterpolations(v, envVars), 0)
+      const headerCount = Object.values(req.headers).reduce((sum, value) => sum + countInterpolations(value, envVars), 0)
       const totalCount = urlCount + headerCount
       if (totalCount > 0) {
         log('info', `Interpolated ${totalCount} environment variable${totalCount !== 1 ? 's' : ''}`)
@@ -193,11 +208,10 @@ export function registerHttpHandlers(): void {
         authConfig: resolvedAuthConfig,
         url: interpolateEnvVars(req.url, envVars),
         headers: Object.fromEntries(
-          Object.entries(req.headers).map(([k, v]) => [k, interpolateEnvVars(v, envVars)])
+          Object.entries(req.headers).map(([key, value]) => [key, interpolateEnvVars(value, envVars)])
         )
       }
 
-      // ── Execute ───────────────────────────────────────────────────────────────
       const controller = new AbortController()
       currentAbortController = controller
       const response = await executeRequest(interpolatedReq, {

--- a/src/main/ipc/requests.ts
+++ b/src/main/ipc/requests.ts
@@ -17,16 +17,16 @@ const CAMEL_TO_SNAKE: Record<string, string> = {
   scmSha: 'scm_sha',
   isDirty: 'is_dirty',
   sortOrder: 'sort_order',
-  groupId: 'group_id',
+  folderId: 'folder_id',
   sslVerification: 'ssl_verification',
   protocol: 'protocol',
   protocolConfig: 'protocol_config',
 }
 
 export function registerRequestHandlers(): void {
-  ipcMain.handle('postly:requests:list', async (_, args: { groupId: string }) => {
+  ipcMain.handle('postly:requests:list', async (_, args: { folderId: string }) => {
     try {
-      return { data: queryAll('SELECT * FROM requests WHERE group_id = ? ORDER BY sort_order ASC', [args.groupId]) }
+      return { data: queryAll('SELECT * FROM requests WHERE folder_id = ? ORDER BY sort_order ASC', [args.folderId]) }
     } catch (err) { return { error: String(err) } }
   })
 
@@ -38,14 +38,14 @@ export function registerRequestHandlers(): void {
 
   ipcMain.handle(
     'postly:requests:create',
-    async (_, args: { groupId: string; name?: string; method?: string }) => {
+    async (_, args: { folderId: string; name?: string; method?: string }) => {
       try {
         const id = crypto.randomUUID()
         const now = Date.now()
         run(
-          `INSERT INTO requests (id, group_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, is_dirty, sort_order, created_at, updated_at)
+          `INSERT INTO requests (id, folder_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, is_dirty, sort_order, created_at, updated_at)
            VALUES (?, ?, ?, ?, '', '[]', '[]', 'none', '', 'none', '{}', 0, 0, ?, ?)`,
-          [id, args.groupId, args.name ?? 'New Request', args.method ?? 'GET', now, now]
+          [id, args.folderId, args.name ?? 'New Request', args.method ?? 'GET', now, now]
         )
         return { data: queryOne('SELECT * FROM requests WHERE id = ?', [id]) }
       } catch (err) { return { error: String(err) } }

--- a/src/main/ipc/requests.ts
+++ b/src/main/ipc/requests.ts
@@ -30,6 +30,12 @@ export function registerRequestHandlers(): void {
     } catch (err) { return { error: String(err) } }
   })
 
+  ipcMain.handle('postly:requests:list-all', async () => {
+    try {
+      return { data: queryAll('SELECT * FROM requests ORDER BY sort_order ASC') }
+    } catch (err) { return { error: String(err) } }
+  })
+
   ipcMain.handle('postly:requests:get', async (_, args: { id: string }) => {
     try {
       return { data: queryOne('SELECT * FROM requests WHERE id = ?', [args.id]) }

--- a/src/main/services/__tests__/backstage.integration.test.ts
+++ b/src/main/services/__tests__/backstage.integration.test.ts
@@ -140,7 +140,7 @@ describe('syncCatalog — standalone API entity', () => {
   it('inserts a new collection row for the API', async () => {
     await syncCatalog(settings())
     const insertCalls = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO collections'),
+      (sql as string).startsWith('INSERT INTO folders') && (sql as string).includes("'backstage'"),
     )
     expect(insertCalls).toHaveLength(1)
     const [sql, params] = insertCalls[0]
@@ -152,10 +152,10 @@ describe('syncCatalog — standalone API entity', () => {
     vi.mocked(queryOne).mockReturnValue({ id: 'existing-coll-id' })
     await syncCatalog(settings())
     const updateCalls = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('UPDATE collections'),
+      (sql as string).startsWith('UPDATE folders'),
     )
     const insertCalls = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO collections'),
+      (sql as string).startsWith('INSERT INTO folders') && (sql as string).includes("'backstage'"),
     )
     expect(updateCalls).toHaveLength(1)
     expect(insertCalls).toHaveLength(0)
@@ -164,7 +164,7 @@ describe('syncCatalog — standalone API entity', () => {
   it('inserts a group row for the pets tag', async () => {
     await syncCatalog(settings())
     const groupInserts = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO groups'),
+      (sql as string).startsWith('INSERT INTO folders'),
     )
     expect(groupInserts.length).toBeGreaterThanOrEqual(1)
     const groupNames = groupInserts.map(([, params]) => (params as unknown[])[2])
@@ -182,7 +182,7 @@ describe('syncCatalog — standalone API entity', () => {
   it('clears old groups and requests before re-importing', async () => {
     await syncCatalog(settings())
     const deleteGroupsCalls = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('DELETE FROM groups'),
+      (sql as string).startsWith('DELETE FROM folders'),
     )
     const deleteRequestsCalls = vi.mocked(run).mock.calls.filter(([sql]) =>
       (sql as string).startsWith('DELETE FROM requests'),
@@ -347,7 +347,7 @@ describe('syncCatalog — component owning API via providesApis', () => {
     expect(result.synced).toBe(1)
 
     const collectionInserts = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO collections'),
+      (sql as string).startsWith('INSERT INTO folders'),
     )
     // The collection should be named after the component, not the API
     expect(collectionInserts[0][1] as unknown[]).toContain('my-service')
@@ -389,7 +389,7 @@ describe('syncCatalog — component owning API via relations', () => {
     expect(result.synced).toBe(1)
 
     const collectionInserts = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO collections'),
+      (sql as string).startsWith('INSERT INTO folders'),
     )
     expect(collectionInserts[0][1] as unknown[]).toContain('my-service')
   })
@@ -424,7 +424,7 @@ describe('syncCatalog — GraphQL API type', () => {
     expect(result.errors).toHaveLength(0)
 
     const groupInserts = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO groups'),
+      (sql as string).startsWith('INSERT INTO folders'),
     )
     const groupNames = groupInserts.map(([, params]) => (params as unknown[])[2])
     expect(groupNames).toContain('GraphQL Schema')
@@ -466,7 +466,7 @@ describe('syncCatalog — gRPC API type', () => {
     expect(result.errors).toHaveLength(0)
 
     const groupInserts = vi.mocked(run).mock.calls.filter(([sql]) =>
-      (sql as string).startsWith('INSERT INTO groups'),
+      (sql as string).startsWith('INSERT INTO folders'),
     )
     const groupNames = groupInserts.map(([, params]) => (params as unknown[])[2])
     expect(groupNames).toContain('gRPC Schema')

--- a/src/main/services/__tests__/openapi-parser.test.ts
+++ b/src/main/services/__tests__/openapi-parser.test.ts
@@ -74,41 +74,40 @@ describe('parseOpenApiToRequests — OAS3', () => {
     mockDereference.mockResolvedValue(OAS3_SPEC as never)
   })
 
-  it('creates one group per unique tag', async () => {
-    const { groups } = await parseOpenApiToRequests({}, 'col-1')
-    const names = groups.map((g) => g.name)
+  it('creates one folder per unique tag', async () => {
+    const { folders } = await parseOpenApiToRequests({}, 'col-1')
+    const names = folders.map((folder) => folder.name)
     expect(names).toContain('Users')
     expect(names).toContain('Products')
-    expect(groups).toHaveLength(2)
+    expect(folders).toHaveLength(2)
   })
 
-  it('sets collectionId on every group', async () => {
-    const { groups } = await parseOpenApiToRequests({}, 'col-1')
-    for (const g of groups) expect(g.collectionId).toBe('col-1')
+  it('sets parentId on every folder', async () => {
+    const { folders } = await parseOpenApiToRequests({}, 'col-1')
+    for (const folder of folders) expect(folder.parentId).toBe('col-1')
   })
 
   it('creates a request for every operation', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    // GET /users, POST /users, GET /users/{id}, DELETE /users/{id}, GET /products = 5
     expect(requests).toHaveLength(5)
   })
 
   it('prepends server base URL to each request URL', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    for (const r of requests) {
-      expect(r.url).toMatch(/^https:\/\/api\.example\.com\/v1\//)
+    for (const request of requests) {
+      expect(request.url).toMatch(/^https:\/\/api\.example\.com\/v1\//)
     }
   })
 
   it('uses summary as request name when available', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    const listUsers = requests.find((r) => r.method === 'GET' && r.url.endsWith('/users'))
+    const listUsers = requests.find((request) => request.method === 'GET' && request.url.endsWith('/users'))
     expect(listUsers?.name).toBe('List users')
   })
 
   it('falls back to operationId when summary is absent', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    const deleteUser = requests.find((r) => r.method === 'DELETE')
+    const deleteUser = requests.find((request) => request.method === 'DELETE')
     expect(deleteUser?.name).toBe('deleteUser')
   })
 
@@ -124,65 +123,66 @@ describe('parseOpenApiToRequests — OAS3', () => {
 
   it('uppercases the HTTP method', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    for (const r of requests) {
-      expect(r.method).toBe(r.method.toUpperCase())
+    for (const request of requests) {
+      expect(request.method).toBe(request.method.toUpperCase())
     }
   })
 
   it('extracts query parameters', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    const listUsers = requests.find((r) => r.method === 'GET' && r.url.endsWith('/users'))
+    const listUsers = requests.find((request) => request.method === 'GET' && request.url.endsWith('/users'))
     if (!listUsers) throw new Error('GET /users request not found')
     const params = JSON.parse(listUsers.params) as Array<{ key: string }>
-    expect(params.map((p) => p.key)).toEqual(['page', 'limit'])
+    expect(params.map((param) => param.key)).toEqual(['page', 'limit'])
   })
 
   it('extracts header parameters', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    const listUsers = requests.find((r) => r.method === 'GET' && r.url.endsWith('/users'))
+    const listUsers = requests.find((request) => request.method === 'GET' && request.url.endsWith('/users'))
     if (!listUsers) throw new Error('GET /users request not found')
     const headers = JSON.parse(listUsers.headers) as Array<{ key: string }>
-    expect(headers.map((h) => h.key)).toEqual(['X-Tenant-Id'])
+    expect(headers.map((header) => header.key)).toEqual(['X-Tenant-Id'])
   })
 
-  it('assigns requests to the correct group', async () => {
-    const { groups, requests } = await parseOpenApiToRequests({}, 'col-1')
-    const usersGroup = groups.find((g) => g.name === 'Users')
-    const productsGroup = groups.find((g) => g.name === 'Products')
-    if (!usersGroup) throw new Error('Users group not found')
-    if (!productsGroup) throw new Error('Products group not found')
-    const userRequests = requests.filter((r) => r.groupId === usersGroup.id)
-    const productRequests = requests.filter((r) => r.groupId === productsGroup.id)
+  it('assigns requests to the correct folder', async () => {
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    const usersFolder = folders.find((folder) => folder.name === 'Users')
+    const productsFolder = folders.find((folder) => folder.name === 'Products')
+    if (!usersFolder) throw new Error('Users folder not found')
+    if (!productsFolder) throw new Error('Products folder not found')
+    const userRequests = requests.filter((request) => request.folderId === usersFolder.id)
+    const productRequests = requests.filter((request) => request.folderId === productsFolder.id)
     expect(userRequests).toHaveLength(4)
     expect(productRequests).toHaveLength(1)
   })
 
   it('initialises all requests with isDirty = 0', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    for (const r of requests) expect(r.isDirty).toBe(0)
+    for (const request of requests) expect(request.isDirty).toBe(0)
   })
 
   it('initialises all requests with authType none', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    for (const r of requests) expect(r.authType).toBe('none')
+    for (const request of requests) expect(request.authType).toBe('none')
   })
 
-  it('assigns incrementing sortOrder to requests', async () => {
-    const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    const orders = requests.map((r) => r.sortOrder)
-    expect(orders).toEqual([...Array(requests.length).keys()])
+  it('assigns incrementing sortOrder within each folder', async () => {
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    for (const folder of folders) {
+      const orders = requests.filter((request) => request.folderId === folder.id).map((request) => request.sortOrder)
+      expect(orders).toEqual([...Array(orders.length).keys()])
+    }
   })
 
-  it('assigns unique UUIDs to all groups and requests', async () => {
-    const { groups, requests } = await parseOpenApiToRequests({}, 'col-1')
-    const allIds = [...groups.map((g) => g.id), ...requests.map((r) => r.id)]
-    const unique = new Set(allIds)
-    expect(unique.size).toBe(allIds.length)
+  it('assigns unique UUIDs to all folders and requests', async () => {
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    const allIds = [...folders.map((folder) => folder.id), ...requests.map((request) => request.id)]
+    expect(new Set(allIds).size).toBe(allIds.length)
   })
 
   it('uses description from operation when present', async () => {
     const { requests } = await parseOpenApiToRequests({}, 'col-1')
-    const deleteUser = requests.find((r) => r.method === 'DELETE')
+    const deleteUser = requests.find((request) => request.method === 'DELETE')
     expect(deleteUser?.description).toBe('Permanently removes a user')
   })
 })
@@ -213,33 +213,32 @@ describe('parseOpenApiToRequests — Swagger 2.x', () => {
 })
 
 describe('parseOpenApiToRequests — edge cases', () => {
-  it('returns empty groups and requests when paths is absent', async () => {
+  it('returns empty folders and requests when paths is absent', async () => {
     mockDereference.mockResolvedValue({ openapi: '3.0.0' } as never)
     const result = await parseOpenApiToRequests({}, 'col-1')
-    expect(result.groups).toHaveLength(0)
+    expect(result.folders).toHaveLength(0)
     expect(result.requests).toHaveLength(0)
   })
 
-  it('uses "Default" tag group for operations without tags', async () => {
+  it('places untagged operations directly in the parent folder', async () => {
     const spec = {
       openapi: '3.0.0',
       servers: [{ url: '' }],
       paths: { '/ping': { get: { summary: 'Ping' } } }
     }
     mockDereference.mockResolvedValue(spec as never)
-    const { groups } = await parseOpenApiToRequests({}, 'col-1')
-    expect(groups[0].name).toBe('Default')
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    expect(folders).toHaveLength(0)
+    expect(requests[0].folderId).toBe('col-1')
   })
 
-  it('reuses the same group for multiple operations sharing a tag', async () => {
+  it('reuses the same folder for multiple operations sharing a tag', async () => {
     mockDereference.mockResolvedValue(OAS3_SPEC as never)
-    const { groups, requests } = await parseOpenApiToRequests({}, 'col-1')
-    const usersGroup = groups.find((g) => g.name === 'Users')
-    if (!usersGroup) throw new Error('Users group not found')
-    const usersRequests = requests.filter((r) => r.groupId === usersGroup.id)
-    // GET /users, POST /users, GET /users/{id}, DELETE /users/{id}
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    const usersFolder = folders.find((folder) => folder.name === 'Users')
+    if (!usersFolder) throw new Error('Users folder not found')
+    const usersRequests = requests.filter((request) => request.folderId === usersFolder.id)
     expect(usersRequests).toHaveLength(4)
-    // Only one Users group was created
-    expect(groups.filter((g) => g.name === 'Users')).toHaveLength(1)
+    expect(folders.filter((folder) => folder.name === 'Users')).toHaveLength(1)
   })
 })

--- a/src/main/services/__tests__/openapi-parser.test.ts
+++ b/src/main/services/__tests__/openapi-parser.test.ts
@@ -82,6 +82,28 @@ describe('parseOpenApiToRequests — OAS3', () => {
     expect(folders).toHaveLength(2)
   })
 
+  it('places a multi-tag operation in the first tag folder', async () => {
+    const spec = {
+      ...OAS3_SPEC,
+      paths: {
+        '/reports': {
+          get: {
+            tags: ['Reports', 'Admin'],
+            summary: 'List reports',
+          }
+        }
+      }
+    }
+    mockDereference.mockResolvedValue(spec as never)
+
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    const reportsFolder = folders.find((folder) => folder.name === 'Reports')
+
+    expect(folders.map((folder) => folder.name)).toEqual(['Reports'])
+    expect(reportsFolder).toBeDefined()
+    expect(requests[0].folderId).toBe(reportsFolder?.id)
+  })
+
   it('sets parentId on every folder', async () => {
     const { folders } = await parseOpenApiToRequests({}, 'col-1')
     for (const folder of folders) expect(folder.parentId).toBe('col-1')
@@ -232,6 +254,26 @@ describe('parseOpenApiToRequests — edge cases', () => {
     expect(requests[0].folderId).toBe('col-1')
   })
 
+  it('treats an empty tags array as untagged and keeps the request in the parent folder', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      servers: [{ url: '' }],
+      paths: {
+        '/health': {
+          get: {
+            tags: [],
+            summary: 'Get health',
+          }
+        }
+      }
+    }
+    mockDereference.mockResolvedValue(spec as never)
+
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    expect(folders).toHaveLength(0)
+    expect(requests[0].folderId).toBe('col-1')
+  })
+
   it('reuses the same folder for multiple operations sharing a tag', async () => {
     mockDereference.mockResolvedValue(OAS3_SPEC as never)
     const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
@@ -240,5 +282,29 @@ describe('parseOpenApiToRequests — edge cases', () => {
     const usersRequests = requests.filter((request) => request.folderId === usersFolder.id)
     expect(usersRequests).toHaveLength(4)
     expect(folders.filter((folder) => folder.name === 'Users')).toHaveLength(1)
+  })
+
+  it('sets request folderId values to the deduplicated folder id for shared tags', async () => {
+    const spec = {
+      openapi: '3.0.0',
+      servers: [{ url: '' }],
+      paths: {
+        '/users': {
+          get: { tags: ['Users'], summary: 'List users' },
+          post: { tags: ['Users'], summary: 'Create user' },
+        }
+      }
+    }
+    mockDereference.mockResolvedValue(spec as never)
+
+    const { folders, requests } = await parseOpenApiToRequests({}, 'col-1')
+    const usersFolder = folders.find((folder) => folder.name === 'Users')
+
+    expect(folders.filter((folder) => folder.name === 'Users')).toHaveLength(1)
+    expect(usersFolder).toBeDefined()
+    expect(requests.map((request) => request.folderId)).toEqual([
+      usersFolder?.id,
+      usersFolder?.id,
+    ])
   })
 })

--- a/src/main/services/backstage.ts
+++ b/src/main/services/backstage.ts
@@ -57,11 +57,7 @@ function resolveOpenApiSpec(definition: string | Record<string, unknown>): objec
   return null
 }
 
-/** Normalise a Backstage entity ref to just the name portion */
 function refName(ref: string): string {
-  // e.g. 'api:default/user-management-api' → 'user-management-api'
-  //       'default/user-management-api'    → 'user-management-api'
-  //       'user-management-api'            → 'user-management-api'
   return ref.replace(/^[^:]+:/i, '').split('/').pop() ?? ref
 }
 
@@ -79,7 +75,6 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
     ? new https.Agent({ rejectUnauthorized: false })
     : undefined
 
-  // Fetch all API + Component entities in parallel
   const [apisRes, compsRes] = await Promise.all([
     axios.get<BackstageApiEntity[]>(`${settings.baseUrl}/api/catalog/entities?filter=kind=API`, { headers, httpsAgent }),
     axios.get<BackstageComponentEntity[]>(`${settings.baseUrl}/api/catalog/entities?filter=kind=Component`, { headers, httpsAgent }),
@@ -88,35 +83,29 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
   const allApis = Array.isArray(apisRes.data) ? apisRes.data : []
   const allComponents = Array.isArray(compsRes.data) ? compsRes.data : []
 
-  // Build fast-lookup: name → API entity
   const apiByName = new Map<string, BackstageApiEntity>()
   for (const api of allApis) apiByName.set(api.metadata.name, api)
 
-  // Group APIs by component using spec.providesApis or relations
   const componentApis = new Map<BackstageComponentEntity, BackstageApiEntity[]>()
   const claimedApiNames = new Set<string>()
 
   for (const comp of allComponents) {
-    // Collect API names via spec.providesApis
     const providedRefs: string[] = comp.spec?.providesApis ?? []
-    // Also collect via relations (type: 'providesApi')
     for (const rel of comp.relations ?? []) {
       if (rel.type === 'providesApi') providedRefs.push(rel.targetRef)
     }
     const apis = [...new Set(providedRefs.map(refName))]
-      .map(name => apiByName.get(name))
-      .filter((a): a is BackstageApiEntity => !!a)
+      .map((name) => apiByName.get(name))
+      .filter((api): api is BackstageApiEntity => !!api)
 
     if (apis.length > 0) {
       componentApis.set(comp, apis)
-      apis.forEach(a => claimedApiNames.add(a.metadata.name))
+      apis.forEach((api) => claimedApiNames.add(api.metadata.name))
     }
   }
 
-  // APIs with no owning component become standalone collections
-  const standaloneApis = allApis.filter(a => !claimedApiNames.has(a.metadata.name))
+  const standaloneApis = allApis.filter((api) => !claimedApiNames.has(api.metadata.name))
 
-  // Build collection list: [{ label, apis }]
   type CollectionSpec = { label: string; sourceMeta: string; apis: BackstageApiEntity[] }
   const collections: CollectionSpec[] = [
     ...Array.from(componentApis.entries()).map(([comp, apis]) => ({
@@ -124,7 +113,7 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
       sourceMeta: JSON.stringify({ component: comp.metadata.name, namespace: comp.metadata.namespace ?? 'default' }),
       apis,
     })),
-    ...standaloneApis.map(api => ({
+    ...standaloneApis.map((api) => ({
       label: api.metadata.name,
       sourceMeta: JSON.stringify({ entityName: api.metadata.name, entityNamespace: api.metadata.namespace ?? 'default' }),
       apis: [api],
@@ -134,29 +123,30 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
   result.entitiesFound = collections.length
   console.warn(`[Backstage] syncCatalog: ${allComponents.length} components, ${allApis.length} APIs → ${collections.length} collections`)
 
-  for (const col of collections) {
-    // Upsert the collection row
-    const existing = queryOne<{ id: string }>(`SELECT id FROM collections WHERE source = 'backstage' AND source_meta = ?`, [col.sourceMeta])
+  for (const collection of collections) {
+    const existing = queryOne<{ id: string }>(`SELECT id FROM folders WHERE parent_id IS NULL AND source = 'backstage' AND source_meta = ?`, [collection.sourceMeta])
     let collectionId: string
     if (existing) {
       collectionId = existing.id
-      run('UPDATE collections SET name = ?, integration_id = ?, updated_at = ? WHERE id = ?', [col.label, settings.integrationId ?? null, now, collectionId])
+      run('UPDATE folders SET name = ?, integration_id = ?, updated_at = ? WHERE id = ?', [collection.label, settings.integrationId ?? null, now, collectionId])
     } else {
       collectionId = crypto.randomUUID()
-    run(`INSERT INTO collections (id, name, source, source_meta, integration_id, created_at, updated_at) VALUES (?, ?, 'backstage', ?, ?, ?, ?)`,
-        [collectionId, col.label, col.sourceMeta, settings.integrationId ?? null, now, now])
+      run(
+        `INSERT INTO folders (id, parent_id, name, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+         VALUES (?, NULL, ?, 'backstage', ?, ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
+        [collectionId, collection.label, collection.sourceMeta, settings.integrationId ?? null, now, now]
+      )
     }
 
-    // Clear old groups + requests before re-importing
-    run('DELETE FROM requests WHERE group_id IN (SELECT id FROM groups WHERE collection_id = ?)', [collectionId])
-    run('DELETE FROM groups WHERE collection_id = ?', [collectionId])
+    run('DELETE FROM requests WHERE folder_id = ?', [collectionId])
+    run('DELETE FROM folders WHERE parent_id = ?', [collectionId])
 
     let anySucceeded = false
-    for (const api of col.apis) {
+    for (const api of collection.apis) {
       const apiName = api.metadata.name
       const apiType = api.spec?.type ?? 'openapi'
       const rawDefinition = api.spec?.definition
-      console.warn(`[Backstage] ${col.label}/${apiName} type=${apiType} hasDefinition=${!!rawDefinition}`)
+      console.warn(`[Backstage] ${collection.label}/${apiName} type=${apiType} hasDefinition=${!!rawDefinition}`)
 
       try {
         if (apiType === 'openapi' || apiType === 'swagger') {
@@ -164,51 +154,65 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
           if (!spec) {
             const specUrl = api.metadata.annotations?.['backstage.io/api-spec']
             if (specUrl) {
-              try { spec = (await axios.get(specUrl, { headers, httpsAgent })).data }
-              catch (err) { result.errors.push(`${col.label}/${apiName}: failed to fetch spec — ${String(err)}`); continue }
+              try {
+                spec = (await axios.get(specUrl, { headers, httpsAgent })).data
+              } catch (err) {
+                result.errors.push(`${collection.label}/${apiName}: failed to fetch spec — ${String(err)}`)
+                continue
+              }
             }
           }
           if (!spec) {
-            result.errors.push(`${col.label}/${apiName}: no definition found (definition=${JSON.stringify(rawDefinition)?.slice(0, 100)})`)
+            result.errors.push(`${collection.label}/${apiName}: no definition found (definition=${JSON.stringify(rawDefinition)?.slice(0, 100)})`)
             continue
           }
-          const { groups, requests } = await parseOpenApiToRequests(spec, collectionId)
-          for (const g of groups) {
-            run(`INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-              [g.id, g.collectionId, g.name, g.description ?? null, g.collapsed ? 1 : 0, g.hidden ? 1 : 0, g.sortOrder, g.createdAt, g.updatedAt])
+
+          const { folders, requests } = await parseOpenApiToRequests(spec, collectionId)
+          for (const folder of folders) {
+            run(
+              `INSERT INTO folders (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+               VALUES (?, ?, ?, ?, 'local', NULL, NULL, 'none', '{}', 'inherit', ?, ?, ?, ?, ?)`,
+              [folder.id, folder.parentId, folder.name, folder.description ?? '', folder.hidden ? 1 : 0, folder.collapsed ? 1 : 0, folder.sortOrder, folder.createdAt, folder.updatedAt]
+            )
           }
-          for (const req of requests) {
-            run(`INSERT INTO requests (id, group_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-              [req.id, req.groupId, req.name, req.method, req.url, req.params, req.headers, req.bodyType,
-               req.bodyContent, req.authType, req.authConfig, req.description ?? null, req.scmPath ?? null,
-               req.scmSha ?? null, req.isDirty ? 1 : 0, req.sortOrder, req.createdAt, req.updatedAt])
+          for (const request of requests) {
+            run(
+              `INSERT INTO requests (id, folder_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              [request.id, request.folderId, request.name, request.method, request.url, request.params, request.headers, request.bodyType,
+                request.bodyContent, request.authType, request.authConfig, request.description ?? null, request.scmPath ?? null,
+                request.scmSha ?? null, request.isDirty ? 1 : 0, request.sortOrder, request.createdAt, request.updatedAt]
+            )
           }
           anySucceeded = true
         } else {
-          // graphql / grpc / asyncapi — store raw definition as a schema request
-          const groupId = crypto.randomUUID()
+          const folderId = crypto.randomUUID()
           const label = apiType === 'graphql' ? 'GraphQL' : apiType === 'grpc' ? 'gRPC' : apiType.toUpperCase()
-          run(`INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, 0, 0, 0, ?, ?)`,
-            [groupId, collectionId, `${label} Schema`, `${label} API from Backstage`, now, now])
+          run(
+            `INSERT INTO folders (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'local', NULL, NULL, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
+            [folderId, collectionId, `${label} Schema`, `${label} API from Backstage`, now, now]
+          )
           const requestId = crypto.randomUUID()
           const definitionStr = typeof rawDefinition === 'string' ? rawDefinition : JSON.stringify(rawDefinition ?? '', null, 2)
           const protocol = apiType === 'grpc' ? 'grpc' : apiType === 'graphql' ? 'graphql' : 'http'
-          // GraphQL: store SDL in protocol_config.schema so it's visible in the schema tab
-          // gRPC: store proto in protocol_config.protoContent (matches GrpcView prop)
           const protocolConfig = apiType === 'graphql'
             ? JSON.stringify({ schema: definitionStr })
             : apiType === 'grpc'
               ? JSON.stringify({ protoContent: definitionStr })
               : '{}'
-          run(`INSERT INTO requests (id, group_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, protocol, protocol_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, ?)`,
-            [requestId, groupId, apiName, 'POST', settings.baseUrl, '[]', '[]',
-             'none', '', 'none', '{}', protocol, protocolConfig,
-             `${label} definition synced from Backstage`, null, null, now, now])
+          run(
+            `INSERT INTO requests (id, folder_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, protocol, protocol_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, ?)`,
+            [requestId, folderId, apiName, 'POST', settings.baseUrl, '[]', '[]',
+              'none', '', 'none', '{}', protocol, protocolConfig,
+              `${label} definition synced from Backstage`, null, null, now, now]
+          )
           anySucceeded = true
         }
       } catch (err) {
-        console.error(`[Backstage] failed to process ${col.label}/${apiName}:`, err)
-        result.errors.push(`${col.label}/${apiName}: ${String(err)}`)
+        console.error(`[Backstage] failed to process ${collection.label}/${apiName}:`, err)
+        result.errors.push(`${collection.label}/${apiName}: ${String(err)}`)
       }
     }
 
@@ -222,10 +226,6 @@ export async function syncCatalog(settings: BackstageSettings): Promise<SyncResu
 
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000
 
-/**
- * Fetch a Backstage guest token. No browser window — just a direct HTTP call
- * to /api/auth/guest/refresh. Works when dangerouslyAllowOutsideDevelopment is true.
- */
 export async function authenticateWithBackstageGuest(
   baseUrl: string,
   options: { sslVerification?: boolean } = {},
@@ -253,13 +253,6 @@ export async function authenticateWithBackstageGuest(
   }
 }
 
-/**
- * Opens a BrowserWindow to the Backstage auth start endpoint for the given
- * provider (e.g. 'gitlab', 'github', 'google'). After the OAuth dance
- * completes and Backstage sets a session, the window's JavaScript context
- * calls the Backstage refresh endpoint (with the session cookies) to
- * retrieve the Backstage-signed token.
- */
 export async function authenticateWithBackstage(
   baseUrl: string,
   provider: string,
@@ -300,7 +293,6 @@ export async function authenticateWithBackstage(
 
     const tryExtract = async () => {
       const url = win.webContents.getURL()
-      // Skip while still in the OAuth redirect dance
       if (url.includes('/api/auth/') || url.includes('/oauth/') || url.includes('/login')) return
       try {
         const result = await win.webContents.executeJavaScript(`

--- a/src/main/services/git-local.ts
+++ b/src/main/services/git-local.ts
@@ -7,7 +7,7 @@ import crypto from 'crypto'
 import SwaggerParser from '@apidevtools/swagger-parser'
 import { queryOne, run } from '../database'
 import { parseOpenApiToRequests } from './openapi-parser'
-import type { PostlyExportFile, ExportCollection } from '../ipc/export-import'
+import type { PostlyExportFile, ExportCollection, ExportFolder, ExportRequest } from '../ipc/export-import'
 
 export function getDataDir(): string {
   return app.getPath('userData')
@@ -203,6 +203,57 @@ export async function commitAndPush(
   await git.push('origin', branch)
 }
 
+function insertExportRequest(
+  request: ExportRequest,
+  folderId: string,
+  scmPath: string,
+  sortOrder: number,
+  now: number
+): void {
+  const reqId = crypto.randomUUID()
+  run(
+    `INSERT INTO requests
+       (id, folder_id, name, method, url, params, headers, body_type, body_content,
+        auth_type, auth_config, ssl_verification, protocol, protocol_config,
+        description, scm_path, is_dirty, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
+    [reqId, folderId, request.name, request.method ?? 'GET', request.url ?? '',
+      JSON.stringify(request.params ?? []), JSON.stringify(request.headers ?? []),
+      request.bodyType ?? 'none', request.bodyContent ?? '',
+      request.auth?.type ?? 'none',
+      JSON.stringify(request.auth?.config ?? {}),
+      request.ssl ?? 'inherit', request.protocol ?? 'http',
+      JSON.stringify(request.protocolConfig ?? {}),
+      request.description ?? '', scmPath, sortOrder, now, now]
+  )
+}
+
+function insertExportFolder(
+  folder: ExportFolder,
+  parentId: string,
+  scmPath: string,
+  sortOrder: number,
+  now: number
+): void {
+  const folderId = crypto.randomUUID()
+  run(
+    `INSERT INTO folders
+      (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config,
+       ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+     VALUES (?, ?, ?, ?, 'local', NULL, NULL, ?, ?, ?, 0, 0, ?, ?, ?)`,
+    [folderId, parentId, folder.name, folder.description ?? '',
+      folder.auth?.type ?? 'none', JSON.stringify(folder.auth?.config ?? {}),
+      folder.ssl ?? 'inherit', sortOrder, now, now]
+  )
+  for (const [ri, req] of (folder.requests ?? []).entries()) {
+    insertExportRequest(req, folderId, scmPath, ri, now)
+  }
+  // fall back to `groups` for .postly.json files committed before the folder-tree refactor
+  for (const [fi, child] of (folder.folders ?? folder.groups ?? []).entries()) {
+    insertExportFolder(child, folderId, scmPath, fi, now)
+  }
+}
+
 /** Import a single Postly collection entry into a DB collection (create or update). */
 function upsertPostlyCollection(
   integrationId: string,
@@ -211,38 +262,18 @@ function upsertPostlyCollection(
   fileName: string,
   now: number
 ) {
-  run('DELETE FROM groups WHERE collection_id = ?', [collectionId])
+  run('DELETE FROM requests WHERE folder_id = ?', [collectionId])
+  run('DELETE FROM folders WHERE parent_id = ?', [collectionId])
   run(
-    'UPDATE collections SET name = ?, source_meta = ?, updated_at = ? WHERE id = ?',
+    'UPDATE folders SET name = ?, source_meta = ?, updated_at = ? WHERE id = ?',
     [col.name, JSON.stringify({ integrationId, fileName }), now, collectionId]
   )
-  for (const [gi, grp] of (col.groups ?? []).entries()) {
-    const grpId = crypto.randomUUID()
-    run(
-      `INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, auth_type, auth_config, ssl_verification, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 0, 0, ?, ?, ?, ?, ?, ?)`,
-      [grpId, collectionId, grp.name, grp.description ?? '', gi,
-       grp.auth?.type ?? 'none', JSON.stringify(grp.auth?.config ?? {}),
-       grp.ssl ?? 'inherit', now, now]
-    )
-    for (const [ri, req] of ((grp.requests ?? []) as unknown as Array<Record<string,unknown>>).entries()) {
-      const reqId = crypto.randomUUID()
-      run(
-        `INSERT INTO requests
-           (id, group_id, name, method, url, params, headers, body_type, body_content,
-            auth_type, auth_config, ssl_verification, protocol, protocol_config,
-            description, scm_path, is_dirty, sort_order, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
-        [reqId, grpId, req.name, req.method ?? 'GET', req.url ?? '',
-         JSON.stringify(req.params ?? []), JSON.stringify(req.headers ?? []),
-         req.bodyType ?? 'none', req.bodyContent ?? '',
-         (req.auth as Record<string,string>)?.type ?? 'none',
-         JSON.stringify((req.auth as Record<string,unknown>)?.config ?? {}),
-         req.ssl ?? 'inherit', req.protocol ?? 'http',
-         JSON.stringify(req.protocolConfig ?? {}),
-         req.description ?? '', fileName, ri, now, now]
-      )
-    }
+  for (const [ri, req] of (col.requests ?? []).entries()) {
+    insertExportRequest(req, collectionId, fileName, ri, now)
+  }
+  // fall back to `groups` for .postly.json files committed before the folder-tree refactor
+  for (const [fi, folder] of (col.folders ?? col.groups ?? []).entries()) {
+    insertExportFolder(folder, collectionId, fileName, fi, now)
   }
 }
 
@@ -263,21 +294,23 @@ async function importOpenApi(integrationId: string, localPath: string, collectio
     if (!fs.existsSync(fullPath)) continue
     let spec: object
     try { spec = await SwaggerParser.dereference(fullPath) } catch { continue }
-    run('UPDATE collections SET source_meta = ?, updated_at = ? WHERE id = ?',
+    run('UPDATE folders SET source_meta = ?, updated_at = ? WHERE id = ?',
       [JSON.stringify({ integrationId, filePath }), now, collectionId])
     try {
-      const { groups, requests } = await parseOpenApiToRequests(spec, collectionId)
-      run('DELETE FROM groups WHERE collection_id = ?', [collectionId])
-      for (const g of groups) {
+      const { folders, requests } = await parseOpenApiToRequests(spec, collectionId)
+      run('DELETE FROM requests WHERE folder_id = ?', [collectionId])
+      run('DELETE FROM folders WHERE parent_id = ?', [collectionId])
+      for (const folder of folders) {
         run(
-          `INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          [g.id, g.collectionId, g.name, g.description ?? null, g.collapsed ? 1 : 0, g.hidden ? 1 : 0, g.sortOrder, g.createdAt, g.updatedAt]
+          `INSERT INTO folders (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 'local', NULL, NULL, 'none', '{}', 'inherit', ?, ?, ?, ?, ?)`,
+          [folder.id, folder.parentId, folder.name, folder.description ?? '', folder.hidden ? 1 : 0, folder.collapsed ? 1 : 0, folder.sortOrder, folder.createdAt, folder.updatedAt]
         )
       }
       for (const req of requests) {
         run(
-          `INSERT INTO requests (id, group_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-          [req.id, req.groupId, req.name, req.method, req.url, req.params, req.headers, req.bodyType,
+          `INSERT INTO requests (id, folder_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [req.id, req.folderId, req.name, req.method, req.url, req.params, req.headers, req.bodyType,
            req.bodyContent, req.authType, req.authConfig, req.description ?? null, filePath, null,
            0, req.sortOrder, req.createdAt, req.updatedAt]
         )
@@ -314,11 +347,11 @@ export async function discoverAndImport(
 
           // Find existing collection by fileName in source_meta, or by name
           const byFile = queryOne<{ id: string }>(
-            `SELECT id FROM collections WHERE integration_id = ? AND source_meta LIKE ?`,
+            `SELECT id FROM folders WHERE parent_id IS NULL AND integration_id = ? AND source_meta LIKE ?`,
             [integrationId, `%"fileName":"${file}"%`]
           )
           const byName = !byFile ? queryOne<{ id: string }>(
-            `SELECT id FROM collections WHERE integration_id = ? AND name = ? AND source = 'git'`,
+            `SELECT id FROM folders WHERE parent_id IS NULL AND integration_id = ? AND name = ? AND source = 'git'`,
             [integrationId, col.name]
           ) : null
 
@@ -330,7 +363,8 @@ export async function discoverAndImport(
           } else {
             colId = crypto.randomUUID()
             run(
-              `INSERT INTO collections (id, name, source, source_meta, integration_id, created_at, updated_at) VALUES (?, ?, 'git', ?, ?, ?, ?)`,
+              `INSERT INTO folders (id, parent_id, name, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+               VALUES (?, NULL, ?, 'git', ?, ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
               [colId, col.name, JSON.stringify({ integrationId, fileName: file }), integrationId, now, now]
             )
           }
@@ -342,17 +376,18 @@ export async function discoverAndImport(
     }
     // No postly files — fall through to OpenAPI for the single-collection sync path
     const existing = queryOne<{ id: string }>(
-      `SELECT id FROM collections WHERE integration_id = ? AND source = 'git' ORDER BY created_at ASC LIMIT 1`,
+      `SELECT id FROM folders WHERE parent_id IS NULL AND integration_id = ? AND source = 'git' ORDER BY created_at ASC LIMIT 1`,
       [integrationId]
     )
     let collectionId: string
     if (existing) {
       collectionId = existing.id
-      run('UPDATE collections SET updated_at = ? WHERE id = ?', [now, collectionId])
+      run('UPDATE folders SET updated_at = ? WHERE id = ?', [now, collectionId])
     } else {
       collectionId = crypto.randomUUID()
       run(
-        `INSERT INTO collections (id, name, source, source_meta, integration_id, created_at, updated_at) VALUES (?, ?, 'git', ?, ?, ?, ?)`,
+        `INSERT INTO folders (id, parent_id, name, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+         VALUES (?, NULL, ?, 'git', ?, ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
         [collectionId, repoName, JSON.stringify({ integrationId }), integrationId, now, now]
       )
     }
@@ -363,17 +398,18 @@ export async function discoverAndImport(
   let collectionId: string
 
   if (opts?.collectionId) {
-    const found = queryOne<{ id: string }>('SELECT id FROM collections WHERE id = ?', [opts.collectionId])
+    const found = queryOne<{ id: string }>('SELECT id FROM folders WHERE id = ?', [opts.collectionId])
     if (found) {
       collectionId = found.id
       run(
-        'UPDATE collections SET source = ?, integration_id = ?, updated_at = ? WHERE id = ?',
+        'UPDATE folders SET source = ?, integration_id = ?, updated_at = ? WHERE id = ?',
         ['git', integrationId, now, collectionId]
       )
     } else {
       collectionId = opts.collectionId
       run(
-        `INSERT INTO collections (id, name, source, source_meta, integration_id, created_at, updated_at) VALUES (?, ?, 'git', ?, ?, ?, ?)`,
+        `INSERT INTO folders (id, parent_id, name, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+         VALUES (?, NULL, ?, 'git', ?, ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
         [collectionId, opts.collectionName ?? repoName, JSON.stringify({ integrationId }), integrationId, now, now]
       )
     }
@@ -381,7 +417,8 @@ export async function discoverAndImport(
     // collectionName supplied → always new
     collectionId = crypto.randomUUID()
     run(
-      `INSERT INTO collections (id, name, source, source_meta, integration_id, created_at, updated_at) VALUES (?, ?, 'git', ?, ?, ?, ?)`,
+      `INSERT INTO folders (id, parent_id, name, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+       VALUES (?, NULL, ?, 'git', ?, ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
       [collectionId, opts.collectionName ?? repoName, JSON.stringify({ integrationId }), integrationId, now, now]
     )
   }

--- a/src/main/services/github.ts
+++ b/src/main/services/github.ts
@@ -38,41 +38,51 @@ export async function discoverApis(settings: GitHubSettings): Promise<void> {
       try {
         const rawResponse = await axios.get(rawUrl, { headers })
         spec = await SwaggerParser.dereference(rawResponse.data)
-      } catch { continue }
+      } catch {
+        continue
+      }
 
       const sourceMeta = JSON.stringify({ org, repo: item.repository.full_name, path: item.path })
-      const existing = queryOne<{ id: string }>(`SELECT id FROM collections WHERE source = 'github' AND source_meta = ?`, [sourceMeta])
+      const existing = queryOne<{ id: string }>(`SELECT id FROM folders WHERE parent_id IS NULL AND source = 'github' AND source_meta = ?`, [sourceMeta])
 
       let collectionId: string
       if (existing) {
         collectionId = existing.id
-        run('UPDATE collections SET updated_at = ? WHERE id = ?', [now, collectionId])
+        run('UPDATE folders SET updated_at = ? WHERE id = ?', [now, collectionId])
       } else {
         collectionId = crypto.randomUUID()
-        run(`INSERT INTO collections (id, name, source, source_meta, created_at, updated_at) VALUES (?, ?, 'github', ?, ?, ?)`,
-          [collectionId, `${item.repository.full_name} / ${item.path}`, sourceMeta, now, now])
+        run(
+          `INSERT INTO folders (id, parent_id, name, source, source_meta, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+           VALUES (?, NULL, ?, 'github', ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
+          [collectionId, `${item.repository.full_name} / ${item.path}`, sourceMeta, now, now]
+        )
       }
 
       try {
-        const { groups, requests } = await parseOpenApiToRequests(spec, collectionId)
-        run('DELETE FROM groups WHERE collection_id = ?', [collectionId])
+        const { folders, requests } = await parseOpenApiToRequests(spec, collectionId)
+        run('DELETE FROM requests WHERE folder_id = ?', [collectionId])
+        run('DELETE FROM folders WHERE parent_id = ?', [collectionId])
 
-        for (const g of groups) {
+        for (const folder of folders) {
           run(
-            `INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-            [g.id, g.collectionId, g.name, g.description ?? null, g.collapsed ? 1 : 0, g.hidden ? 1 : 0, g.sortOrder, g.createdAt, g.updatedAt]
+            `INSERT INTO folders (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+             VALUES (?, ?, ?, ?, 'local', NULL, NULL, 'none', '{}', 'inherit', ?, ?, ?, ?, ?)`,
+            [folder.id, folder.parentId, folder.name, folder.description ?? '', folder.hidden ? 1 : 0, folder.collapsed ? 1 : 0, folder.sortOrder, folder.createdAt, folder.updatedAt]
           )
         }
 
-        for (const req of requests) {
+        for (const request of requests) {
           run(
-            `INSERT INTO requests (id, group_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-            [req.id, req.groupId, req.name, req.method, req.url, req.params, req.headers, req.bodyType,
-             req.bodyContent, req.authType, req.authConfig, req.description ?? null, item.path, item.sha,
-             req.isDirty ? 1 : 0, req.sortOrder, req.createdAt, req.updatedAt]
+            `INSERT INTO requests (id, folder_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            [request.id, request.folderId, request.name, request.method, request.url, request.params, request.headers, request.bodyType,
+              request.bodyContent, request.authType, request.authConfig, request.description ?? null, item.path, item.sha,
+              request.isDirty ? 1 : 0, request.sortOrder, request.createdAt, request.updatedAt]
           )
         }
-      } catch { /* skip unparseable */ }
+      } catch {
+        /* skip unparseable */
+      }
     }
   }
 }

--- a/src/main/services/gitlab.ts
+++ b/src/main/services/gitlab.ts
@@ -44,41 +44,51 @@ export async function discoverApis(settings: GitLabSettings): Promise<void> {
             { headers }
           )
           spec = await SwaggerParser.dereference(rawResponse.data)
-        } catch { continue }
+        } catch {
+          continue
+        }
 
         const sourceMeta = JSON.stringify({ projectId: project.id, projectPath: project.path_with_namespace, filePath })
-        const existing = queryOne<{ id: string }>(`SELECT id FROM collections WHERE source = 'gitlab' AND source_meta = ?`, [sourceMeta])
+        const existing = queryOne<{ id: string }>(`SELECT id FROM folders WHERE parent_id IS NULL AND source = 'gitlab' AND source_meta = ?`, [sourceMeta])
 
         let collectionId: string
         if (existing) {
           collectionId = existing.id
-          run('UPDATE collections SET updated_at = ? WHERE id = ?', [now, collectionId])
+          run('UPDATE folders SET updated_at = ? WHERE id = ?', [now, collectionId])
         } else {
           collectionId = crypto.randomUUID()
-          run(`INSERT INTO collections (id, name, source, source_meta, created_at, updated_at) VALUES (?, ?, 'gitlab', ?, ?, ?)`,
-            [collectionId, project.path_with_namespace, sourceMeta, now, now])
+          run(
+            `INSERT INTO folders (id, parent_id, name, source, source_meta, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+             VALUES (?, NULL, ?, 'gitlab', ?, 'none', '{}', 'inherit', 0, 0, 0, ?, ?)`,
+            [collectionId, project.path_with_namespace, sourceMeta, now, now]
+          )
         }
 
         try {
-          const { groups: parsedGroups, requests } = await parseOpenApiToRequests(spec, collectionId)
-          run('DELETE FROM groups WHERE collection_id = ?', [collectionId])
+          const { folders, requests } = await parseOpenApiToRequests(spec, collectionId)
+          run('DELETE FROM requests WHERE folder_id = ?', [collectionId])
+          run('DELETE FROM folders WHERE parent_id = ?', [collectionId])
 
-          for (const g of parsedGroups) {
+          for (const folder of folders) {
             run(
-              `INSERT INTO groups (id, collection_id, name, description, collapsed, hidden, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-              [g.id, g.collectionId, g.name, g.description ?? null, g.collapsed ? 1 : 0, g.hidden ? 1 : 0, g.sortOrder, g.createdAt, g.updatedAt]
+              `INSERT INTO folders (id, parent_id, name, description, source, source_meta, integration_id, auth_type, auth_config, ssl_verification, hidden, collapsed, sort_order, created_at, updated_at)
+               VALUES (?, ?, ?, ?, 'local', NULL, NULL, 'none', '{}', 'inherit', ?, ?, ?, ?, ?)`,
+              [folder.id, folder.parentId, folder.name, folder.description ?? '', folder.hidden ? 1 : 0, folder.collapsed ? 1 : 0, folder.sortOrder, folder.createdAt, folder.updatedAt]
             )
           }
 
-          for (const req of requests) {
+          for (const request of requests) {
             run(
-              `INSERT INTO requests (id, group_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-              [req.id, req.groupId, req.name, req.method, req.url, req.params, req.headers, req.bodyType,
-               req.bodyContent, req.authType, req.authConfig, req.description ?? null, filePath, null,
-               req.isDirty ? 1 : 0, req.sortOrder, req.createdAt, req.updatedAt]
+              `INSERT INTO requests (id, folder_id, name, method, url, params, headers, body_type, body_content, auth_type, auth_config, description, scm_path, scm_sha, is_dirty, sort_order, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+              [request.id, request.folderId, request.name, request.method, request.url, request.params, request.headers, request.bodyType,
+                request.bodyContent, request.authType, request.authConfig, request.description ?? null, filePath, null,
+                request.isDirty ? 1 : 0, request.sortOrder, request.createdAt, request.updatedAt]
             )
           }
-        } catch { /* skip unparseable */ }
+        } catch {
+          /* skip unparseable */
+        }
         break
       }
     }

--- a/src/main/services/http-executor.ts
+++ b/src/main/services/http-executor.ts
@@ -18,7 +18,7 @@ export interface HttpRequest {
   bodyType: string
   authType: string
   authConfig: Record<string, string>
-  groupId?: string
+  folderId?: string
   sslVerification?: string
 }
 

--- a/src/main/services/openapi-parser.ts
+++ b/src/main/services/openapi-parser.ts
@@ -1,9 +1,9 @@
 import SwaggerParser from '@apidevtools/swagger-parser'
 import crypto from 'crypto'
 
-export interface ParsedGroup {
+export interface ParsedFolder {
   id: string
-  collectionId: string
+  parentId: string
   name: string
   description: string
   collapsed: boolean
@@ -15,7 +15,7 @@ export interface ParsedGroup {
 
 export interface ParsedRequest {
   id: string
-  groupId: string
+  folderId: string
   name: string
   method: string
   url: string
@@ -34,14 +34,15 @@ export interface ParsedRequest {
   updatedAt: number
 }
 
-/** Build a minimal JSON skeleton from an OpenAPI schema object */
 function buildJsonSkeleton(schema: Record<string, unknown>, depth = 0): string {
   if (depth > 4) return 'null'
   const type = schema['type'] as string | undefined
   if (type === 'object' || schema['properties']) {
     const props = (schema['properties'] ?? {}) as Record<string, Record<string, unknown>>
     const pairs = Object.entries(props).map(([k, v]) => `  "${k}": ${buildJsonSkeleton(v, depth + 1)}`)
-    return pairs.length > 0 ? `{\n${pairs.join(',\n')}\n}` : '{}'
+    return pairs.length > 0 ? `{
+${pairs.join(',\n')}
+}` : '{}'
   }
   if (type === 'array' && schema['items']) {
     return `[${buildJsonSkeleton(schema['items'] as Record<string, unknown>, depth + 1)}]`
@@ -54,46 +55,44 @@ function buildJsonSkeleton(schema: Record<string, unknown>, depth = 0): string {
 
 export async function parseOpenApiToRequests(
   spec: object,
-  collectionId: string
-): Promise<{ groups: ParsedGroup[]; requests: ParsedRequest[] }> {
+  parentId: string
+): Promise<{ folders: ParsedFolder[]; requests: ParsedRequest[] }> {
   const dereferenced = (await SwaggerParser.dereference(spec as never)) as Record<string, unknown>
 
   const now = Date.now()
-  const groups: ParsedGroup[] = []
+  const folders: ParsedFolder[] = []
   const requests: ParsedRequest[] = []
 
-  const groupMap = new Map<string, ParsedGroup>()
+  const folderMap = new Map<string, ParsedFolder>()
 
-  function getOrCreateGroup(tag: string): ParsedGroup {
-    const existing = groupMap.get(tag)
+  function getOrCreateFolder(tag: string): ParsedFolder {
+    const existing = folderMap.get(tag)
     if (existing) return existing
-    const group: ParsedGroup = {
+    const folder: ParsedFolder = {
       id: crypto.randomUUID(),
-      collectionId,
+      parentId,
       name: tag,
       description: '',
       collapsed: false,
       hidden: false,
-      sortOrder: groups.length,
+      sortOrder: folders.length,
       createdAt: now,
-      updatedAt: now
+      updatedAt: now,
     }
-    groupMap.set(tag, group)
-    groups.push(group)
-    return group
+    folderMap.set(tag, folder)
+    folders.push(folder)
+    return folder
   }
 
   const paths = dereferenced['paths'] as Record<string, Record<string, unknown>> | undefined
-  if (!paths) return { groups, requests }
+  if (!paths) return { folders, requests }
 
-  // Determine base URL
   let baseUrl = ''
   const isOas3 = !!(dereferenced['openapi'] as string | undefined)?.startsWith('3')
   if (isOas3) {
     const servers = dereferenced['servers'] as Array<{ url: string }> | undefined
     baseUrl = servers?.[0]?.url ?? ''
   } else {
-    // Swagger 2.x
     const schemes = dereferenced['schemes'] as string[] | undefined
     const scheme = schemes?.[0] ?? 'https'
     const host = (dereferenced['host'] as string | undefined) ?? ''
@@ -109,15 +108,12 @@ export async function parseOpenApiToRequests(
       if (!operation) continue
 
       const tags = (operation['tags'] as string[] | undefined) ?? []
-      const tag = tags[0] ?? 'Default'
-      const group = getOrCreateGroup(tag)
+      const folder = tags[0] ? getOrCreateFolder(tags[0]) : null
 
       const operationId = (operation['operationId'] as string | undefined) ?? ''
       const summary = (operation['summary'] as string | undefined) ?? ''
       const description = (operation['description'] as string | undefined) ?? summary
-
       const name = summary || operationId || `${method.toUpperCase()} ${pathKey}`
-
       const parameters = (operation['parameters'] as Array<Record<string, unknown>> | undefined) ?? []
 
       const queryParams = parameters
@@ -128,8 +124,7 @@ export async function parseOpenApiToRequests(
         .filter((p) => p['in'] === 'header')
         .map((p) => ({ id: crypto.randomUUID(), key: String(p['name'] ?? ''), value: '', enabled: true }))
 
-      // Derive body type and content from requestBody
-      let bodyType: string = 'none'
+      let bodyType = 'none'
       let bodyContent = ''
       const requestBody = operation['requestBody'] as { content?: Record<string, { schema?: unknown }> } | undefined
       if (requestBody?.content) {
@@ -149,7 +144,7 @@ export async function parseOpenApiToRequests(
 
       requests.push({
         id: crypto.randomUUID(),
-        groupId: group.id,
+        folderId: folder?.id ?? parentId,
         name,
         method: method.toUpperCase(),
         url: `${baseUrl}${pathKey}`,
@@ -163,12 +158,12 @@ export async function parseOpenApiToRequests(
         scmPath: null,
         scmSha: null,
         isDirty: 0,
-        sortOrder: requests.length,
+        sortOrder: requests.filter((request) => request.folderId === (folder?.id ?? parentId)).length,
         createdAt: now,
-        updatedAt: now
+        updatedAt: now,
       })
     }
   }
 
-  return { groups, requests }
+  return { folders, requests }
 }

--- a/src/main/services/updater.ts
+++ b/src/main/services/updater.ts
@@ -37,7 +37,6 @@ let _autoUpdater: AutoUpdater | null = null
 function getAutoUpdater(): AutoUpdater {
   if (_autoUpdater) return _autoUpdater
   // Lazy import — only in packaged builds to avoid cross-platform binary issues
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
   return (require('electron-updater') as { autoUpdater: AutoUpdater }).autoUpdater
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -26,6 +26,7 @@ const api = {
   },
   requests: {
     list: (data: { folderId: string }) => ipcRenderer.invoke('postly:requests:list', data),
+    listAll: () => ipcRenderer.invoke('postly:requests:list-all'),
     get: (data: { id: string }) => ipcRenderer.invoke('postly:requests:get', data),
     create: (data: { folderId: string; name?: string; method?: string }) => ipcRenderer.invoke('postly:requests:create', data),
     update: (data: { id: string; [key: string]: unknown }) => ipcRenderer.invoke('postly:requests:update', data),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,24 +1,33 @@
 import { contextBridge, ipcRenderer } from 'electron'
 
 const api = {
+  folders: {
+    list: () => ipcRenderer.invoke('postly:folders:list'),
+    create: (data: { parentId?: string; name: string; source?: string; integrationId?: string }) => ipcRenderer.invoke('postly:folders:create', data),
+    delete: (data: { id: string; commitMessage?: string }) => ipcRenderer.invoke('postly:folders:delete', data),
+    rename: (data: { id: string; name: string }) => ipcRenderer.invoke('postly:folders:rename', data),
+    update: (data: { id: string; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sslVerification?: string; collapsed?: boolean; parentId?: string | null; sortOrder?: number; hidden?: boolean }) =>
+      ipcRenderer.invoke('postly:folders:update', data),
+    moveSource: (data: { id: string; source: string }) => ipcRenderer.invoke('postly:folders:move-source', data),
+  },
   collections: {
-    list: () => ipcRenderer.invoke('postly:collections:list'),
-    create: (data: { name: string; source?: string; integrationId?: string }) => ipcRenderer.invoke('postly:collections:create', data),
-    delete: (data: { id: string; commitMessage?: string }) => ipcRenderer.invoke('postly:collections:delete', data),
-    rename: (data: { id: string; name: string }) => ipcRenderer.invoke('postly:collections:rename', data),
-    update: (data: { id: string; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sslVerification?: string; collapsed?: boolean }) =>
-      ipcRenderer.invoke('postly:collections:update', data),
-    moveSource: (data: { id: string; source: string }) => ipcRenderer.invoke('postly:collections:move-source', data),
+    list: () => ipcRenderer.invoke('postly:folders:list'),
+    create: (data: { parentId?: string; name: string; source?: string; integrationId?: string }) => ipcRenderer.invoke('postly:folders:create', data),
+    delete: (data: { id: string; commitMessage?: string }) => ipcRenderer.invoke('postly:folders:delete', data),
+    rename: (data: { id: string; name: string }) => ipcRenderer.invoke('postly:folders:rename', data),
+    update: (data: { id: string; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sslVerification?: string; collapsed?: boolean; parentId?: string | null; sortOrder?: number; hidden?: boolean }) =>
+      ipcRenderer.invoke('postly:folders:update', data),
+    moveSource: (data: { id: string; source: string }) => ipcRenderer.invoke('postly:folders:move-source', data),
   },
   groups: {
-    create: (data: { collectionId: string; name: string; description?: string }) => ipcRenderer.invoke('postly:groups:create', data),
+    create: (data: { collectionId?: string; parentId?: string; name: string; description?: string }) => ipcRenderer.invoke('postly:groups:create', data),
     delete: (data: { id: string }) => ipcRenderer.invoke('postly:groups:delete', data),
-    update: (data: { id: string; collapsed?: boolean; hidden?: boolean; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sortOrder?: number; collectionId?: string }) => ipcRenderer.invoke('postly:groups:update', data),
+    update: (data: { id: string; collapsed?: boolean; hidden?: boolean; name?: string; description?: string; authType?: string; authConfig?: Record<string, string>; sortOrder?: number; collectionId?: string; parentId?: string | null; sslVerification?: string }) => ipcRenderer.invoke('postly:groups:update', data),
   },
   requests: {
-    list: (data: { groupId: string }) => ipcRenderer.invoke('postly:requests:list', data),
+    list: (data: { folderId: string }) => ipcRenderer.invoke('postly:requests:list', data),
     get: (data: { id: string }) => ipcRenderer.invoke('postly:requests:get', data),
-    create: (data: { groupId: string; name?: string; method?: string }) => ipcRenderer.invoke('postly:requests:create', data),
+    create: (data: { folderId: string; name?: string; method?: string }) => ipcRenderer.invoke('postly:requests:create', data),
     update: (data: { id: string; [key: string]: unknown }) => ipcRenderer.invoke('postly:requests:update', data),
     delete: (data: { id: string }) => ipcRenderer.invoke('postly:requests:delete', data),
     markDirty: (data: { id: string; isDirty: boolean }) => ipcRenderer.invoke('postly:requests:mark-dirty', data),
@@ -197,7 +206,7 @@ const api = {
       return () => { ipcRenderer.removeListener('postly:window:maximize-change', handler) }
     },
   },
-  reorder: (data: { type: 'request' | 'group'; updates: Array<{ id: string; sortOrder: number; newParentId?: string }> }) =>
+  reorder: (data: { type: 'request' | 'folder' | 'group'; updates: Array<{ id: string; sortOrder: number; newParentId?: string }> }) =>
     ipcRenderer.invoke('postly:reorder', data),
   drafts: {
     request: {

--- a/src/renderer/src/components/ai/AiChatPanel.tsx
+++ b/src/renderer/src/components/ai/AiChatPanel.tsx
@@ -26,7 +26,7 @@ interface ChatMessage {
 
 interface Props {
   context: AiContext
-  groupId?: string
+  folderId?: string
 }
 
 function parseEndpoints(content: string): { text: string; endpoints: EndpointDraft[] } {
@@ -59,7 +59,7 @@ const STARTERS_BY_TYPE: Record<string, string[]> = {
   ],
 }
 
-export function AiChatPanel({ context, groupId }: Props) {
+export function AiChatPanel({ context, folderId }: Props) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
@@ -68,9 +68,8 @@ export function AiChatPanel({ context, groupId }: Props) {
   const requestIdRef = useRef<string>('')
   const streamBufferRef = useRef<string>('')
 
-  const createLocalRequest = useCollectionsStore((s) => s.createLocalRequest)
-  const groups = useCollectionsStore((s) => s.groups)
-  const aiSettings = useSettingsStore((s) => s.ai)
+  const createLocalRequest = useCollectionsStore((state) => state.createLocalRequest)
+  const aiSettings = useSettingsStore((state) => state.ai)
 
   useEffect(() => {
     const unsub = window.api.ai.onChunk((payload) => {
@@ -118,7 +117,7 @@ export function AiChatPanel({ context, groupId }: Props) {
     const systemPrompt = buildSystemPrompt(context)
     const apiMessages = [
       { role: 'system', content: systemPrompt },
-      ...newMessages.map((m) => ({ role: m.role, content: m.content })),
+      ...newMessages.map((message) => ({ role: message.role, content: message.content })),
     ]
     await window.api.ai.chat({ requestId, provider, model, messages: apiMessages })
   }
@@ -126,22 +125,18 @@ export function AiChatPanel({ context, groupId }: Props) {
   const cancel = () => { window.api.ai.cancel({ requestId: requestIdRef.current }); setStreaming(false) }
 
   const addEndpoint = async (msgIdx: number, epIdx: number, ep: EndpointDraft) => {
-    let targetGroupId = groupId
-    if (!targetGroupId) {
-      const colGroups = context.collectionId ? groups.filter((g) => g.collectionId === context.collectionId) : []
-      targetGroupId = colGroups[0]?.id
-    }
-    if (!targetGroupId) return
-    const beforeIds = new Set(useCollectionsStore.getState().requests.map((r) => r.id))
-    await createLocalRequest(targetGroupId)
-    await new Promise((r) => setTimeout(r, 150))
-    const newReq = useCollectionsStore.getState().requests.find((r) => !beforeIds.has(r.id) && r.groupId === targetGroupId)
+    const targetFolderId = folderId ?? context.folderId ?? context.collectionId
+    if (!targetFolderId) return
+    const beforeIds = new Set(useCollectionsStore.getState().requests.map((request) => request.id))
+    await createLocalRequest(targetFolderId)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    const newReq = useCollectionsStore.getState().requests.find((request) => !beforeIds.has(request.id) && request.folderId === targetFolderId)
     if (newReq) {
       await window.api.requests.update({
         id: newReq.id, name: ep.name, protocol: ep.protocol, method: ep.method, url: ep.url,
         description: ep.description,
-        params: JSON.stringify(ep.params.map((p) => ({ ...p, id: p.id || crypto.randomUUID() }))),
-        headers: JSON.stringify(ep.headers.map((h) => ({ ...h, id: h.id || crypto.randomUUID() }))),
+        params: JSON.stringify(ep.params.map((param) => ({ ...param, id: param.id || crypto.randomUUID() }))),
+        headers: JSON.stringify(ep.headers.map((header) => ({ ...header, id: header.id || crypto.randomUUID() }))),
         bodyType: ep.bodyType, bodyContent: ep.bodyContent,
       })
       await useCollectionsStore.getState().load()
@@ -156,14 +151,13 @@ export function AiChatPanel({ context, groupId }: Props) {
 
   return (
     <div className="flex h-full w-full flex-col bg-th-bg">
-      {/* Header */}
       <div className="drag-region flex shrink-0 items-center border-b border-th-border px-6 pt-8 pb-4">
         <div className="no-drag">
-          <div className="flex items-center gap-2 mb-0.5">
+          <div className="mb-0.5 flex items-center gap-2">
             <Sparkles className="h-4 w-4 text-blue-400" />
             <h1 className="text-sm font-semibold text-th-text-primary">AI Assistant</h1>
           </div>
-          <p className="text-xs text-th-text-muted flex items-center gap-1.5 flex-wrap">
+          <p className="flex flex-wrap items-center gap-1.5 text-xs text-th-text-muted">
             <span>{context.type === 'request' ? '🔍 Reviewing' : '✨ Building'}</span>
             {context.collectionName && (
               <>
@@ -171,127 +165,125 @@ export function AiChatPanel({ context, groupId }: Props) {
                 <span className="text-th-text-subtle">{context.collectionName}</span>
               </>
             )}
-            {context.groupName && (
+            {context.folderName && (
               <>
                 <span className="text-th-text-faint">/</span>
-                <span className="text-th-text-subtle">{context.groupName}</span>
+                <span className="text-th-text-subtle">{context.folderName}</span>
               </>
             )}
             <span className="text-th-text-faint">·</span>
-            <span className="text-th-text-secondary font-medium">{contextLabel}</span>
+            <span className="font-medium text-th-text-secondary">{contextLabel}</span>
           </p>
         </div>
       </div>
 
-      {/* Messages */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto py-6">
-        <div className="mx-auto w-full max-w-3xl px-8 space-y-5">
-        {messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full gap-4 text-center max-w-md mx-auto">
-            <Sparkles className="h-10 w-10 text-blue-400/50" />
-            <div>
-              <p className="text-base font-medium text-th-text-secondary mb-1">
-                {context.type === 'request' ? 'Review or extend this endpoint' : 'What would you like to build?'}
-              </p>
-              <p className="text-sm text-th-text-faint">
-                {context.type === 'request'
-                  ? 'Ask for a review, improvements, or generate related endpoints.'
-                  : 'Describe the API endpoints you need — REST, GraphQL, WebSocket, gRPC, or MQTT.'}
-              </p>
-            </div>
-            <div className="flex flex-col gap-2 w-full mt-2">
-              {starters.map((s) => (
-                <button
-                  key={s}
-                  onClick={() => setInput(s)}
-                  className="rounded-lg border border-th-border px-4 py-2.5 text-left text-sm text-th-text-muted hover:border-blue-500/50 hover:bg-blue-500/5 hover:text-th-text-primary transition-colors"
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {messages.map((msg, msgIdx) => (
-          <div key={msgIdx} className={cn('flex flex-col gap-2', msg.role === 'user' ? 'items-end' : 'items-start')}>
-            <div className={cn(
-              'max-w-[80%] rounded-xl px-4 py-2.5 text-sm leading-relaxed whitespace-pre-wrap',
-              msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-th-surface-raised text-th-text-primary'
-            )}>
-              {msg.content || (streaming && msgIdx === messages.length - 1
-                ? <Loader2 className="h-3.5 w-3.5 animate-spin text-th-text-faint" />
-                : '')}
-            </div>
-
-            {msg.endpoints && msg.endpoints.length > 0 && (
-              <div className="w-full max-w-[80%] space-y-2 mt-1">
-                <p className="text-xs text-th-text-faint px-1">{msg.endpoints.length} endpoint{msg.endpoints.length !== 1 ? 's' : ''} generated</p>
-                {msg.endpoints.map((ep, epIdx) => {
-                  const isAdded = addedMap[msgIdx]?.has(epIdx)
-                  return (
-                    <div key={epIdx} className="rounded-lg border border-th-border bg-th-surface px-4 py-3 flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className={cn(
-                            'rounded-sm px-1.5 py-0.5 text-[10px] font-bold uppercase shrink-0',
-                            ep.protocol === 'http'
-                              ? ep.method === 'GET' ? 'bg-emerald-900/40 text-emerald-400'
-                              : ep.method === 'POST' ? 'bg-blue-900/40 text-blue-400'
-                              : ep.method === 'PUT' || ep.method === 'PATCH' ? 'bg-amber-900/40 text-amber-400'
-                              : ep.method === 'DELETE' ? 'bg-rose-900/40 text-rose-400'
-                              : 'bg-th-surface-raised text-th-text-muted'
-                              : 'bg-purple-900/40 text-purple-400'
-                          )}>
-                            {ep.protocol === 'http' ? ep.method : ep.protocol.toUpperCase()}
-                          </span>
-                          <span className="text-sm font-medium text-th-text-primary truncate">{ep.name}</span>
-                        </div>
-                        <p className="text-xs text-th-text-faint font-mono truncate">{ep.url}</p>
-                        {ep.description && <p className="text-xs text-th-text-subtle mt-1 line-clamp-2">{ep.description}</p>}
-                      </div>
-                      <button
-                        onClick={() => addEndpoint(msgIdx, epIdx, ep)}
-                        disabled={isAdded}
-                        className={cn(
-                          'shrink-0 flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus:outline-hidden',
-                          isAdded ? 'bg-emerald-900/30 text-emerald-500 cursor-default' : 'bg-blue-600 text-white hover:bg-blue-500'
-                        )}
-                      >
-                        {isAdded ? '✓ Added' : <><Plus className="h-3 w-3" /> Add</>}
-                      </button>
-                    </div>
-                  )
-                })}
+        <div className="mx-auto w-full max-w-3xl space-y-5 px-8">
+          {messages.length === 0 && (
+            <div className="mx-auto flex h-full max-w-md flex-col items-center justify-center gap-4 text-center">
+              <Sparkles className="h-10 w-10 text-blue-400/50" />
+              <div>
+                <p className="mb-1 text-base font-medium text-th-text-secondary">
+                  {context.type === 'request' ? 'Review or extend this endpoint' : 'What would you like to build?'}
+                </p>
+                <p className="text-sm text-th-text-faint">
+                  {context.type === 'request'
+                    ? 'Ask for a review, improvements, or generate related endpoints.'
+                    : 'Describe the API endpoints you need — REST, GraphQL, WebSocket, gRPC, or MQTT.'}
+                </p>
               </div>
-            )}
-          </div>
-        ))}
+              <div className="mt-2 flex w-full flex-col gap-2">
+                {starters.map((starter) => (
+                  <button
+                    key={starter}
+                    onClick={() => setInput(starter)}
+                    className="rounded-lg border border-th-border px-4 py-2.5 text-left text-sm text-th-text-muted transition-colors hover:border-blue-500/50 hover:bg-blue-500/5 hover:text-th-text-primary"
+                  >
+                    {starter}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {messages.map((msg, msgIdx) => (
+            <div key={msgIdx} className={cn('flex flex-col gap-2', msg.role === 'user' ? 'items-end' : 'items-start')}>
+              <div className={cn(
+                'max-w-[80%] whitespace-pre-wrap rounded-xl px-4 py-2.5 text-sm leading-relaxed',
+                msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-th-surface-raised text-th-text-primary'
+              )}>
+                {msg.content || (streaming && msgIdx === messages.length - 1
+                  ? <Loader2 className="h-3.5 w-3.5 animate-spin text-th-text-faint" />
+                  : '')}
+              </div>
+
+              {msg.endpoints && msg.endpoints.length > 0 && (
+                <div className="mt-1 w-full max-w-[80%] space-y-2">
+                  <p className="px-1 text-xs text-th-text-faint">{msg.endpoints.length} endpoint{msg.endpoints.length !== 1 ? 's' : ''} generated</p>
+                  {msg.endpoints.map((ep, epIdx) => {
+                    const isAdded = addedMap[msgIdx]?.has(epIdx)
+                    return (
+                      <div key={epIdx} className="flex items-start justify-between gap-3 rounded-lg border border-th-border bg-th-surface px-4 py-3">
+                        <div className="min-w-0">
+                          <div className="mb-1 flex items-center gap-2">
+                            <span className={cn(
+                              'shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-bold uppercase',
+                              ep.protocol === 'http'
+                                ? ep.method === 'GET' ? 'bg-emerald-900/40 text-emerald-400'
+                                  : ep.method === 'POST' ? 'bg-blue-900/40 text-blue-400'
+                                    : ep.method === 'PUT' || ep.method === 'PATCH' ? 'bg-amber-900/40 text-amber-400'
+                                      : ep.method === 'DELETE' ? 'bg-rose-900/40 text-rose-400'
+                                        : 'bg-th-surface-raised text-th-text-muted'
+                                : 'bg-purple-900/40 text-purple-400'
+                            )}>
+                              {ep.protocol === 'http' ? ep.method : ep.protocol.toUpperCase()}
+                            </span>
+                            <span className="truncate text-sm font-medium text-th-text-primary">{ep.name}</span>
+                          </div>
+                          <p className="truncate font-mono text-xs text-th-text-faint">{ep.url}</p>
+                          {ep.description && <p className="mt-1 line-clamp-2 text-xs text-th-text-subtle">{ep.description}</p>}
+                        </div>
+                        <button
+                          onClick={() => addEndpoint(msgIdx, epIdx, ep)}
+                          disabled={isAdded}
+                          className={cn(
+                            'flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors focus:outline-hidden',
+                            isAdded ? 'cursor-default bg-emerald-900/30 text-emerald-500' : 'bg-blue-600 text-white hover:bg-blue-500'
+                          )}
+                        >
+                          {isAdded ? '✓ Added' : <><Plus className="h-3 w-3" /> Add</>}
+                        </button>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       </div>
 
-      {/* Input */}
       <div className="shrink-0 border-t border-th-border py-4">
         <div className="mx-auto w-full max-w-3xl px-8">
           <div className="flex items-end gap-3">
-          <textarea
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }}
-            placeholder={context.type === 'request' ? 'Ask for a review or request changes…' : 'Describe the endpoints you need…'}
-            rows={2}
-            className="flex-1 resize-none rounded-lg border border-th-border bg-th-surface px-4 py-2.5 text-sm text-th-text-primary placeholder:text-th-text-faint focus:border-blue-500/50 focus:outline-hidden focus:ring-1 focus:ring-blue-500/30"
-          />
-          <button
-            onClick={streaming ? cancel : send}
-            disabled={!streaming && !input.trim()}
-            className={cn(
-              'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors focus:outline-hidden',
-              streaming ? 'bg-rose-600 text-white hover:bg-rose-500' : 'bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40'
-            )}
-          >
-            {streaming ? <StopCircle className="h-4 w-4" /> : <Send className="h-4 w-4" />}
-          </button>
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send() } }}
+              placeholder={context.type === 'request' ? 'Ask for a review or request changes…' : 'Describe the endpoints you need…'}
+              rows={2}
+              className="flex-1 resize-none rounded-lg border border-th-border bg-th-surface px-4 py-2.5 text-sm text-th-text-primary placeholder:text-th-text-faint focus:border-blue-500/50 focus:outline-hidden focus:ring-1 focus:ring-blue-500/30"
+            />
+            <button
+              onClick={streaming ? cancel : send}
+              disabled={!streaming && !input.trim()}
+              className={cn(
+                'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors focus:outline-hidden',
+                streaming ? 'bg-rose-600 text-white hover:bg-rose-500' : 'bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-40'
+              )}
+            >
+              {streaming ? <StopCircle className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+            </button>
           </div>
           <p className="mt-2 text-[11px] text-th-text-faint">Enter to send · Shift+Enter for new line · Configure API key in Settings → AI</p>
         </div>

--- a/src/renderer/src/components/editor/CommitPanel.tsx
+++ b/src/renderer/src/components/editor/CommitPanel.tsx
@@ -17,7 +17,7 @@ export function CommitPanel({ requestId, source }: CommitPanelProps) {
   const addToast = useUIStore((s) => s.addToast)
   const theme = useUIStore((s) => s.theme)
   const requests = useCollectionsStore((s) => s.requests)
-  const groups = useCollectionsStore((s) => s.groups)
+  const folders = useCollectionsStore((s) => s.folders)
   const collections = useCollectionsStore((s) => s.collections)
   const [commitMessage, setCommitMessage] = useState('')
   const [branches, setBranches] = useState<string[]>([])
@@ -32,8 +32,11 @@ export function CommitPanel({ requestId, source }: CommitPanelProps) {
 
   useEffect(() => {
     const request = requests.find((r) => r.id === requestId)
-    const group = request ? groups.find((g) => g.id === request.groupId) : undefined
-    const collection = group ? collections.find((c) => c.id === group.collectionId) : undefined
+    let folder = request ? folders.find((item) => item.id === request.folderId) : undefined
+    while (folder?.parentId) {
+      folder = folders.find((item) => item.id === folder?.parentId)
+    }
+    const collection = folder ? collections.find((item) => item.id === folder.id) : undefined
     const sourceMeta = collection?.sourceMeta ?? {}
 
     if (source === 'github') {
@@ -49,7 +52,7 @@ export function CommitPanel({ requestId, source }: CommitPanelProps) {
         if (data) { setBranches(data); setSelectedBranch(data[0] ?? ''); setFromBranch(data[0] ?? '') }
       })
     }
-  }, [requestId, source, requests, groups, collections])
+  }, [requestId, source, requests, folders, collections])
 
   const handleShowDiff = async () => {
     if (showDiff) { setShowDiff(false); return }

--- a/src/renderer/src/components/editor/GroupEditor.tsx
+++ b/src/renderer/src/components/editor/GroupEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { ChevronRight, FolderOpen, Folder, HardDrive, GitFork, GitBranch, Box } from 'lucide-react'
-import type { AuthType, SslVerification } from '@/types'
+import type { AuthType, Folder as FolderType, SslVerification } from '@/types'
 import { AuthEditor } from '@/components/editor/AuthEditor'
 import { SslEditor } from '@/components/editor/SslEditor'
 import { useCollectionsStore } from '@/store/collections'
@@ -11,9 +11,9 @@ import { AiActionButton } from '@/components/ai/AiActionButton'
 function SourceCrumb({ source, name }: { source: string; name: string }) {
   const icon =
     source === 'github' ? <GitFork className="h-3 w-3" /> :
-    source === 'gitlab' ? <GitBranch className="h-3 w-3" /> :
-    source === 'backstage' ? <Box className="h-3 w-3" /> :
-    <HardDrive className="h-3 w-3" />
+      source === 'gitlab' ? <GitBranch className="h-3 w-3" /> :
+        source === 'backstage' ? <Box className="h-3 w-3" /> :
+          <HardDrive className="h-3 w-3" />
   return (
     <span className="flex items-center gap-1 px-1.5 py-0.5 text-th-text-faint">
       {icon}
@@ -23,7 +23,7 @@ function SourceCrumb({ source, name }: { source: string; name: string }) {
 }
 
 interface Props {
-  groupId: string
+  folderId: string
 }
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
@@ -38,15 +38,23 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   )
 }
 
-export function GroupEditor({ groupId }: Props) {
-  const group = useCollectionsStore((s) => s.groups.find((g) => g.id === groupId))
-  const collections = useCollectionsStore((s) => s.collections)
-  const updateGroup = useCollectionsStore((s) => s.updateGroup)
-  const integrations = useIntegrationsStore((s) => s.integrations)
-  const addToast = useUIStore((s) => s.addToast)
-  const selectItem = useUIStore((s) => s.selectItem)
-  const openGitAction = useUIStore((s) => s.openGitAction)
-  const setEditorDirty = useUIStore((s) => s.setEditorDirty)
+function findRootCollection(folder: FolderType | undefined, folders: FolderType[]): FolderType | null {
+  let current = folder
+  while (current?.parentId) {
+    current = folders.find((candidate) => candidate.id === current?.parentId)
+  }
+  return current ?? null
+}
+
+export function GroupEditor({ folderId }: Props) {
+  const folders = useCollectionsStore((state) => state.folders)
+  const folder = useCollectionsStore((state) => state.groups.find((item) => item.id === folderId))
+  const updateGroup = useCollectionsStore((state) => state.updateGroup)
+  const integrations = useIntegrationsStore((state) => state.integrations)
+  const addToast = useUIStore((state) => state.addToast)
+  const selectItem = useUIStore((state) => state.selectItem)
+  const openGitAction = useUIStore((state) => state.openGitAction)
+  const setEditorDirty = useUIStore((state) => state.setEditorDirty)
 
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
@@ -75,17 +83,14 @@ export function GroupEditor({ groupId }: Props) {
     if (undoPushTimer.current) { clearTimeout(undoPushTimer.current); undoPushTimer.current = null }
   }
 
-  const scheduleDraft = (fields: {
-    name: string; description: string
-    authType: AuthType; authConfig: Record<string, string>; sslVerification: SslVerification
-  }) => {
+  const scheduleDraft = (fields: FormSnapshot) => {
     pendingDraftData.current = fields
     if (draftTimer.current) clearTimeout(draftTimer.current)
     draftTimer.current = setTimeout(() => {
       draftTimer.current = null
       pendingDraftData.current = null
       window.api.drafts.group.upsert({
-        groupId,
+        groupId: folderId,
         name: fields.name,
         description: fields.description,
         authType: fields.authType,
@@ -95,39 +100,38 @@ export function GroupEditor({ groupId }: Props) {
     }, 500)
   }
 
-  const collection = group ? collections.find((c) => c.id === group.collectionId) : null
+  const collection = findRootCollection(folder, folders)
+  const integration = collection?.integrationId ? integrations.find((item) => item.id === collection.integrationId) : null
 
   useEffect(() => {
-    if (!group) return
+    if (!folder) return
     const load = async () => {
-      // Reset dirty immediately so the sidebar indicator clears while draft loads
-      setEditorDirty(groupId, false)
-      // Capture saved state before any draft overlay
+      setEditorDirty(folderId, false)
       savedSnapshot.current = {
-        name: group.name,
-        description: group.description ?? '',
-        authType: group.authType,
-        authConfig: group.authConfig,
-        sslVerification: group.sslVerification ?? 'inherit',
+        name: folder.name,
+        description: folder.description ?? '',
+        authType: folder.authType,
+        authConfig: folder.authConfig,
+        sslVerification: folder.sslVerification ?? 'inherit',
       }
       try {
-        const { data } = await window.api.drafts.group.get({ groupId }) as { data: Record<string, unknown> | null }
+        const { data } = await window.api.drafts.group.get({ groupId: folderId }) as { data: Record<string, unknown> | null }
         if (data) {
-          setName((data.name as string) ?? group.name)
-          setDescription((data.description as string) ?? group.description ?? '')
-          setAuthType(((data.auth_type as AuthType) ?? group.authType))
-          setAuthConfig(typeof data.auth_config === 'string' ? JSON.parse(data.auth_config as string) : group.authConfig)
-          setSslVerification(((data.ssl_verification as SslVerification) ?? group.sslVerification ?? 'inherit'))
+          setName((data.name as string) ?? folder.name)
+          setDescription((data.description as string) ?? folder.description ?? '')
+          setAuthType(((data.auth_type as AuthType) ?? folder.authType))
+          setAuthConfig(typeof data.auth_config === 'string' ? JSON.parse(data.auth_config as string) : folder.authConfig)
+          setSslVerification(((data.ssl_verification as SslVerification) ?? folder.sslVerification ?? 'inherit'))
           setIsDirty(true)
-          setEditorDirty(groupId, true)
+          setEditorDirty(folderId, true)
           return
         }
       } catch { /* fall through to saved state */ }
-      setName(group.name)
-      setDescription(group.description ?? '')
-      setAuthType(group.authType)
-      setAuthConfig(group.authConfig)
-      setSslVerification(group.sslVerification ?? 'inherit')
+      setName(folder.name)
+      setDescription(folder.description ?? '')
+      setAuthType(folder.authType)
+      setAuthConfig(folder.authConfig)
+      setSslVerification(folder.sslVerification ?? 'inherit')
       setIsDirty(false)
     }
     load()
@@ -138,22 +142,17 @@ export function GroupEditor({ groupId }: Props) {
         const pending = pendingDraftData.current
         if (pending) {
           pendingDraftData.current = null
-          window.api.drafts.group.upsert({ groupId, name: pending.name, description: pending.description, authType: pending.authType, authConfig: JSON.stringify(pending.authConfig), sslVerification: pending.sslVerification })
+          window.api.drafts.group.upsert({ groupId: folderId, name: pending.name, description: pending.description, authType: pending.authType, authConfig: JSON.stringify(pending.authConfig), sslVerification: pending.sslVerification })
         }
       }
       clearUndo()
-      setEditorDirty(groupId, false)
+      setEditorDirty(folderId, false)
     }
-  }, [groupId, group, setEditorDirty])
+  }, [folderId, folder, setEditorDirty])
 
-  // No separate isDirty sync effect — setEditorDirty is called directly
-  // in load/save/discard/mark/handleUndo to avoid stale-state race on group switch
-
-  if (!group) {
-    return <div className="flex h-full items-center justify-center text-sm text-th-text-subtle">Group not found</div>
+  if (!folder) {
+    return <div className="flex h-full items-center justify-center text-sm text-th-text-subtle">Folder not found</div>
   }
-
-  const integration = collection?.integrationId ? integrations.find((i) => i.id === collection.integrationId) : null
 
   let inheritedAuthFrom: string | undefined
   if (collection && collection.authType !== 'none' && collection.authType !== 'inherit') {
@@ -165,14 +164,14 @@ export function GroupEditor({ groupId }: Props) {
   const discard = async () => {
     if (draftTimer.current) { clearTimeout(draftTimer.current); draftTimer.current = null }
     clearUndo()
-    await window.api.drafts.group.delete({ groupId })
-    setName(group.name)
-    setDescription(group.description ?? '')
-    setAuthType(group.authType)
-    setAuthConfig(group.authConfig)
-    setSslVerification(group.sslVerification ?? 'inherit')
+    await window.api.drafts.group.delete({ groupId: folderId })
+    setName(folder.name)
+    setDescription(folder.description ?? '')
+    setAuthType(folder.authType)
+    setAuthConfig(folder.authConfig)
+    setSslVerification(folder.sslVerification ?? 'inherit')
     setIsDirty(false)
-    setEditorDirty(groupId, false)
+    setEditorDirty(folderId, false)
   }
 
   const save = async () => {
@@ -180,36 +179,30 @@ export function GroupEditor({ groupId }: Props) {
     if (draftTimer.current) { clearTimeout(draftTimer.current); draftTimer.current = null }
     clearUndo()
     setSaving(true)
-    await updateGroup(groupId, { name: name.trim(), description, authType, authConfig, sslVerification })
-    await window.api.drafts.group.delete({ groupId })
+    await updateGroup(folderId, { name: name.trim(), description, authType, authConfig, sslVerification })
+    await window.api.drafts.group.delete({ groupId: folderId })
     setSaving(false)
     setIsDirty(false)
-    setEditorDirty(groupId, false)
-    const isGit= collection && ['git', 'github', 'gitlab'].includes(collection.source)
+    setEditorDirty(folderId, false)
+    const isGit = collection && ['git', 'github', 'gitlab'].includes(collection.source)
     if (isGit && collection) {
-      openGitAction({ type: 'push', collectionId: collection.id, title: `Updated group '${name.trim()}'`, subtitle: collection.name })
+      openGitAction({ type: 'push', collectionId: collection.id, title: `Updated folder '${name.trim()}'`, subtitle: collection.name })
     } else {
-      addToast('Group saved', 'success')
+      addToast('Folder saved', 'success')
     }
   }
 
-  const mark = (fields?: {
-    name?: string; description?: string
-    authType?: AuthType; authConfig?: Record<string, string>; sslVerification?: SslVerification
-  }, changedField?: string) => {
-    const currentSnapshot: FormSnapshot = {
-      name: name, description: description, authType: authType,
-      authConfig: authConfig, sslVerification: sslVerification,
-    }
+  const mark = (fields?: Partial<FormSnapshot>, changedField?: string) => {
+    const currentSnapshot: FormSnapshot = { name, description, authType, authConfig, sslVerification }
     if (changedField !== lastUndoField.current) {
       if (undoPushTimer.current) { clearTimeout(undoPushTimer.current); undoPushTimer.current = null }
       pushUndo(currentSnapshot)
       lastUndoField.current = changedField ?? null
     } else if (!undoPushTimer.current) {
-      const snap = { ...currentSnapshot, authConfig: { ...currentSnapshot.authConfig } }
+      const snapshot = { ...currentSnapshot, authConfig: { ...currentSnapshot.authConfig } }
       undoPushTimer.current = setTimeout(() => {
         undoPushTimer.current = null
-        pushUndo(snap)
+        pushUndo(snapshot)
       }, 1000)
     }
     const newState = {
@@ -222,13 +215,13 @@ export function GroupEditor({ groupId }: Props) {
     const atSaved = savedSnapshot.current !== null && JSON.stringify(newState) === JSON.stringify(savedSnapshot.current)
     if (atSaved) {
       setIsDirty(false)
-      setEditorDirty(groupId, false)
+      setEditorDirty(folderId, false)
       if (draftTimer.current) { clearTimeout(draftTimer.current); draftTimer.current = null }
       if (undoPushTimer.current) { clearTimeout(undoPushTimer.current); undoPushTimer.current = null }
-      window.api.drafts.group.delete({ groupId })
+      window.api.drafts.group.delete({ groupId: folderId })
     } else {
       setIsDirty(true)
-      setEditorDirty(groupId, true)
+      setEditorDirty(folderId, true)
       scheduleDraft(newState)
     }
   }
@@ -243,16 +236,15 @@ export function GroupEditor({ groupId }: Props) {
     setAuthType(previous.authType)
     setAuthConfig(previous.authConfig)
     setSslVerification(previous.sslVerification)
-    // Dirty only if the restored snapshot differs from the originally saved state
     const atSaved = savedSnapshot.current && JSON.stringify(previous) === JSON.stringify(savedSnapshot.current)
     if (atSaved) {
       setIsDirty(false)
-      setEditorDirty(groupId, false)
+      setEditorDirty(folderId, false)
       if (draftTimer.current) { clearTimeout(draftTimer.current); draftTimer.current = null }
-      window.api.drafts.group.delete({ groupId })
+      window.api.drafts.group.delete({ groupId: folderId })
     } else {
       setIsDirty(true)
-      setEditorDirty(groupId, true)
+      setEditorDirty(folderId, true)
       scheduleDraft(previous)
     }
   }
@@ -268,92 +260,83 @@ export function GroupEditor({ groupId }: Props) {
 
   return (
     <div className="flex h-full flex-col bg-th-bg" onKeyDown={onKeyDown}>
-      {/* Thin drag strip — window drag target only, no content */}
       <div className="drag-region shrink-0 pt-8 pb-4" />
-      {/* Scrollable content */}
       <div className="no-drag flex-1 overflow-y-auto">
-      <div className="px-8 pb-4 flex flex-col gap-6 border-b border-th-border">
-
-        {/* Title with breadcrumb */}
-        <div className="no-drag">
-          <div className="mb-3 inline-flex items-center gap-1.5 text-xs flex-wrap">
-            <SourceCrumb
-              source={collection?.source ?? 'local'}
-              name={integration ? integration.name : 'Local'}
+        <div className="flex flex-col gap-6 border-b border-th-border px-8 pb-4">
+          <div className="no-drag">
+            <div className="mb-3 inline-flex flex-wrap items-center gap-1.5 text-xs">
+              <SourceCrumb
+                source={collection?.source ?? 'local'}
+                name={integration ? integration.name : 'Local'}
+              />
+              {collection && (
+                <>
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-th-text-faint" />
+                  <button
+                    onClick={() => selectItem('collection', collection.id)}
+                    className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 font-medium text-th-text-subtle hover:bg-th-surface-hover hover:text-th-text-primary focus:outline-hidden"
+                  >
+                    <FolderOpen className="h-3.5 w-3.5 shrink-0" />
+                    {collection.name}
+                  </button>
+                </>
+              )}
+              <ChevronRight className="h-3.5 w-3.5 shrink-0 text-th-text-faint" />
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 font-medium text-th-text-primary">
+                <Folder className="h-3.5 w-3.5 shrink-0" />
+                {name || 'Folder'}
+              </span>
+            </div>
+            <input
+              data-testid="group-name-input"
+              className="-mx-2 w-full cursor-text rounded-md border border-transparent bg-transparent px-2 py-1 text-2xl font-semibold text-th-text-primary placeholder:text-th-text-faint outline-hidden transition-colors hover:border-th-border hover:bg-th-surface-hover focus:border-th-border-strong focus:bg-th-surface"
+              placeholder="Folder name"
+              value={name}
+              onChange={(e) => { setName(e.target.value); mark({ name: e.target.value }, 'name') }}
             />
-            {collection && (
-              <>
-                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-th-text-faint" />
-                <button
-                  onClick={() => selectItem('collection', collection.id)}
-                  className="inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 font-medium text-th-text-subtle hover:bg-th-surface-hover hover:text-th-text-primary focus:outline-hidden"
-                >
-                  <FolderOpen className="h-3.5 w-3.5 shrink-0" />
-                  {collection.name}
-                </button>
-              </>
-            )}
-            <ChevronRight className="h-3.5 w-3.5 shrink-0 text-th-text-faint" />
-            <span className="inline-flex items-center gap-1 px-1.5 py-0.5 font-medium text-th-text-primary">
-              <Folder className="h-3.5 w-3.5 shrink-0" />
-              {name || 'Group'}
-            </span>
+            <p className="mt-1 text-xs text-th-text-faint">Folder</p>
+            <AiActionButton
+              className="mt-3 rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm hover:border-blue-500/60 hover:bg-blue-500/15"
+              onClick={() => selectItem('ai-group', folderId)}
+            />
           </div>
-          <input
-            data-testid="group-name-input"
-            className="-mx-2 w-full cursor-text rounded-md border border-transparent bg-transparent px-2 py-1 text-2xl font-semibold text-th-text-primary placeholder:text-th-text-faint outline-hidden transition-colors hover:border-th-border hover:bg-th-surface-hover focus:border-th-border-strong focus:bg-th-surface"
-            placeholder="Group name"
-            value={name}
-            onChange={(e) => { setName(e.target.value); mark({ name: e.target.value }, 'name') }}
-          />
-          <p className="mt-1 text-xs text-th-text-faint">Group</p>
-          <AiActionButton
-            className="mt-3 rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm hover:border-blue-500/60 hover:bg-blue-500/15"
-            onClick={() => selectItem('ai-group', groupId)}
-          />
+
+          <Section title="Description">
+            <textarea
+              className="w-full resize-none rounded-md border border-th-border bg-th-surface px-3 py-2.5 text-sm leading-relaxed text-th-text-secondary placeholder-th-text-faint focus:border-th-border-strong focus:outline-hidden"
+              placeholder="Describe what this folder contains, e.g. which service or feature area."
+              rows={4}
+              value={description}
+              onChange={(e) => { setDescription(e.target.value); mark({ description: e.target.value }, 'description') }}
+            />
+          </Section>
+
+          <Section title="Authentication">
+            <p className="mb-3 text-xs text-th-text-faint">
+              Default auth for all requests in this folder. Use <strong className="text-th-text-subtle">Inherit</strong> to fall through to the collection or integration auth.
+            </p>
+            <AuthEditor
+              authType={authType}
+              authConfig={authConfig}
+              onChange={(type, config) => { setAuthType(type); setAuthConfig(config); mark({ authType: type, authConfig: config }, 'auth') }}
+              inheritedFrom={inheritedAuthFrom}
+              canInherit={true}
+            />
+          </Section>
+
+          <Section title="SSL Verification">
+            <p className="mb-3 text-xs text-th-text-faint">
+              Default SSL setting for requests in this folder. Use <strong className="text-th-text-subtle">Inherit</strong> to fall through to the collection setting.
+            </p>
+            <SslEditor
+              value={sslVerification}
+              onChange={(value) => { setSslVerification(value); mark({ sslVerification: value }, 'ssl') }}
+              inheritedFrom={collection?.sslVerification !== 'inherit' ? collection?.name : undefined}
+            />
+          </Section>
         </div>
-
-        {/* Description */}
-        <Section title="Description">
-          <textarea
-            className="w-full resize-none rounded-md border border-th-border bg-th-surface px-3 py-2.5 text-sm text-th-text-secondary placeholder-th-text-faint focus:border-th-border-strong focus:outline-hidden leading-relaxed"
-            placeholder="Describe what this group contains, e.g. which service or feature area."
-            rows={4}
-            value={description}
-            onChange={(e) => { setDescription(e.target.value); mark({ description: e.target.value }, 'description') }}
-          />
-        </Section>
-
-        {/* Auth */}
-        <Section title="Authentication">
-          <p className="mb-3 text-xs text-th-text-faint">
-            Default auth for all requests in this group. Use <strong className="text-th-text-subtle">Inherit</strong> to fall through to the collection or integration auth.
-          </p>
-          <AuthEditor
-            authType={authType}
-            authConfig={authConfig}
-            onChange={(t, c) => { setAuthType(t); setAuthConfig(c); mark({ authType: t, authConfig: c }, 'auth') }}
-            inheritedFrom={inheritedAuthFrom}
-            canInherit={true}
-          />
-        </Section>
-
-        {/* SSL */}
-        <Section title="SSL Verification">
-          <p className="mb-3 text-xs text-th-text-faint">
-            Default SSL setting for requests in this group. Use <strong className="text-th-text-subtle">Inherit</strong> to fall through to the collection setting.
-          </p>
-          <SslEditor
-            value={sslVerification}
-            onChange={(v) => { setSslVerification(v); mark({ sslVerification: v }, 'ssl') }}
-            inheritedFrom={collection?.sslVerification !== 'inherit' ? collection?.name : undefined}
-          />
-        </Section>
-
       </div>
-      </div>{/* end scroll wrapper */}
 
-      {/* Save bar */}
       <div className="no-drag flex items-center justify-end gap-2 border-t border-th-border px-8 py-3">
         {isDirty && (
           <button

--- a/src/renderer/src/components/editor/RequestEditor.tsx
+++ b/src/renderer/src/components/editor/RequestEditor.tsx
@@ -52,8 +52,7 @@ function pcGet(config: Record<string, string>, key: string): string {
 
 export function RequestEditor() {
   const { editingRequest, isLoading, updateField, sendRequest, cancelRequest, saveRequest, discardDraft, undoRequest } = useRequestsStore()
-  const collections = useCollectionsStore((s) => s.collections)
-  const groups = useCollectionsStore((s) => s.groups)
+  const folders = useCollectionsStore((s) => s.folders)
   const integrations = useIntegrationsStore((s) => s.integrations)
   const { selectItem } = useUIStore()
   const openGitAction = useUIStore((s) => s.openGitAction)
@@ -62,15 +61,19 @@ export function RequestEditor() {
 
   const breadcrumb = useMemo(() => {
     if (!editingRequest) return null
-    const group = groups.find((g) => g.id === editingRequest.groupId)
-    const collection = group ? collections.find((c) => c.id === group.collectionId) : undefined
+    const folder = folders.find((item) => item.id === editingRequest.folderId)
+    let collection = folder
+    while (collection?.parentId) {
+      collection = folders.find((item) => item.id === collection?.parentId)
+    }
+    const isRootRequest = folder && collection && folder.id === collection.id
     const integration = collection?.integrationId
       ? integrations.find((i) => i.id === collection.integrationId)
       : null
     const sourceLabel = integration ? integration.name : 'Local'
     const sourceType = collection?.source ?? 'local'
-    return { group, collection, integration, sourceLabel, sourceType }
-  }, [editingRequest, groups, collections, integrations])
+    return { folder, collection, integration, sourceLabel, sourceType, isRootRequest }
+  }, [editingRequest, folders, integrations])
 
   const sourceIcon = (type: string) => {
     if (type === 'github') return <GitFork className="h-3 w-3" />
@@ -181,13 +184,13 @@ export function RequestEditor() {
                 />
               </>
             )}
-            {breadcrumb.group && (
+            {breadcrumb.folder && !breadcrumb.isRootRequest && (
               <>
                 <ChevronRight className="h-3 w-3 shrink-0 text-th-text-faint" />
                 <BreadcrumbItem
                   icon={<Folder className="h-3 w-3" />}
-                  label={breadcrumb.group.name}
-                  onClick={() => selectItem('group', breadcrumb.group?.id ?? '')}
+                  label={breadcrumb.folder.name}
+                  onClick={() => selectItem('group', breadcrumb.folder?.id ?? '')}
                 />
               </>
             )}

--- a/src/renderer/src/components/editor/tabs/__tests__/BodyTab.test.tsx
+++ b/src/renderer/src/components/editor/tabs/__tests__/BodyTab.test.tsx
@@ -2,7 +2,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type React from 'react'
 import type { BodyType } from '@/types'
 
 // ── Monaco mock ───────────────────────────────────────────────────────────────

--- a/src/renderer/src/components/editor/tabs/__tests__/BodyTab.test.tsx
+++ b/src/renderer/src/components/editor/tabs/__tests__/BodyTab.test.tsx
@@ -8,7 +8,7 @@ import type { BodyType } from '@/types'
 // @monaco-editor/react is a heavy runtime dependency not available in jsdom.
 
 vi.mock('@monaco-editor/react', async () => {
-  const React = await import('react')
+  const _React = await import('react')
   const Editor = ({ value, onChange, 'data-testid': testId }: {
     value?: string
     onChange?: (v: string) => void

--- a/src/renderer/src/components/editor/tabs/__tests__/BodyTab.test.tsx
+++ b/src/renderer/src/components/editor/tabs/__tests__/BodyTab.test.tsx
@@ -8,7 +8,6 @@ import type { BodyType } from '@/types'
 // @monaco-editor/react is a heavy runtime dependency not available in jsdom.
 
 vi.mock('@monaco-editor/react', async () => {
-  const _React = await import('react')
   const Editor = ({ value, onChange, 'data-testid': testId }: {
     value?: string
     onChange?: (v: string) => void

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -16,35 +16,65 @@ import { ImportPage } from '@/components/export-import/ImportPage'
 import { WindowControls } from '@/components/layout/WindowControls'
 import { useUIStore } from '@/store/ui'
 import { useCollectionsStore } from '@/store/collections'
-import type { AiContext } from '@/lib/aiContext'
+import type { AiContext, } from '@/lib/aiContext'
+import type { Folder } from '@/types'
+
+function findRootCollection(folderId: string, folders: Folder[]): Folder | undefined {
+  let current = folders.find((folder) => folder.id === folderId)
+  while (current?.parentId) {
+    current = folders.find((folder) => folder.id === current?.parentId)
+  }
+  return current
+}
 
 function AiCollectionPage({ collectionId }: { collectionId: string }) {
-  const collection = useCollectionsStore((s) => s.collections.find((c) => c.id === collectionId))
-  const groups = useCollectionsStore((s) => s.groups.filter((g) => g.collectionId === collectionId))
-  const allRequests = useCollectionsStore((s) => s.requests)
-  const existingRequests = allRequests.filter((r) => groups.some((g) => g.id === r.groupId))
+  const collection = useCollectionsStore((state) => state.collections.find((item) => item.id === collectionId))
+  const folders = useCollectionsStore((state) => state.folders)
+  const requests = useCollectionsStore((state) => state.requests)
+  const folderIds = new Set(folders.filter((folder) => findRootCollection(folder.id, folders)?.id === collectionId).map((folder) => folder.id))
+  folderIds.add(collectionId)
+  const existingRequests = requests.filter((request) => folderIds.has(request.folderId))
   if (!collection) return null
   const ctx: AiContext = { type: 'collection', collectionId, name: collection.name, description: collection.description, existingRequests }
   return <AiChatPanel context={ctx} />
 }
 
-function AiGroupPage({ groupId }: { groupId: string }) {
-  const group = useCollectionsStore((s) => s.groups.find((g) => g.id === groupId))
-  const collection = useCollectionsStore((s) => s.collections.find((c) => c.id === group?.collectionId))
-  const existingRequests = useCollectionsStore((s) => s.requests.filter((r) => r.groupId === groupId))
-  if (!group) return null
-  const ctx: AiContext = { type: 'group', collectionId: group.collectionId, groupId, name: group.name, collectionName: collection?.name, description: group.description, existingRequests }
-  return <AiChatPanel context={ctx} groupId={groupId} />
+function AiGroupPage({ folderId }: { folderId: string }) {
+  const folders = useCollectionsStore((state) => state.folders)
+  const folder = useCollectionsStore((state) => state.groups.find((item) => item.id === folderId))
+  const collection = folder ? findRootCollection(folder.id, folders) : undefined
+  const existingRequests = useCollectionsStore((state) => state.requests.filter((request) => request.folderId === folderId))
+  if (!folder) return null
+  const ctx: AiContext = {
+    type: 'group',
+    collectionId: collection?.id,
+    folderId,
+    name: folder.name,
+    collectionName: collection?.name,
+    description: folder.description,
+    existingRequests,
+  }
+  return <AiChatPanel context={ctx} folderId={folderId} />
 }
 
 function AiRequestPage({ requestId }: { requestId: string }) {
-  const request = useCollectionsStore((s) => s.requests.find((r) => r.id === requestId))
-  const group = useCollectionsStore((s) => s.groups.find((g) => g.id === request?.groupId))
-  const collection = useCollectionsStore((s) => s.collections.find((c) => c.id === group?.collectionId))
-  const siblingRequests = useCollectionsStore((s) => s.requests.filter((r) => r.groupId === request?.groupId))
+  const request = useCollectionsStore((state) => state.requests.find((item) => item.id === requestId))
+  const folders = useCollectionsStore((state) => state.folders)
+  const folder = request ? folders.find((item) => item.id === request.folderId) : undefined
+  const collection = request ? findRootCollection(request.folderId, folders) : undefined
+  const siblingRequests = useCollectionsStore((state) => state.requests.filter((item) => item.folderId === request?.folderId))
   if (!request) return null
-  const ctx: AiContext = { type: 'request', collectionId: group?.collectionId, groupId: request.groupId, name: request.name, collectionName: collection?.name, groupName: group?.name, existingRequests: siblingRequests, currentRequest: request }
-  return <AiChatPanel context={ctx} groupId={request.groupId} />
+  const ctx: AiContext = {
+    type: 'request',
+    collectionId: collection?.id,
+    folderId: request.folderId,
+    name: request.name,
+    collectionName: collection?.name,
+    folderName: folder?.name,
+    existingRequests: siblingRequests,
+    currentRequest: request,
+  }
+  return <AiChatPanel context={ctx} folderId={request.folderId} />
 }
 
 function useDrag(direction: 'horizontal' | 'vertical', containerRef: React.RefObject<HTMLDivElement | null>, min: number, max: number, onCommit: (size: number) => void) {
@@ -77,24 +107,19 @@ function useDrag(direction: 'horizontal' | 'vertical', containerRef: React.RefOb
 }
 
 export function AppShell() {
-  // Only subscribe to values that affect rendering — not sidebarWidth/editorHeight,
-  // which are managed via DOM refs during drag and committed to the store on mouseup.
-  const sidebarTab = useUIStore((s) => s.sidebarTab)
-  const selectedItem = useUIStore((s) => s.selectedItem)
-  const setSidebarWidth = useUIStore((s) => s.setSidebarWidth)
-  const setEditorHeight = useUIStore((s) => s.setEditorHeight)
+  const sidebarTab = useUIStore((state) => state.sidebarTab)
+  const selectedItem = useUIStore((state) => state.selectedItem)
+  const setSidebarWidth = useUIStore((state) => state.setSidebarWidth)
+  const setEditorHeight = useUIStore((state) => state.setEditorHeight)
 
   const sidebarRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<HTMLDivElement>(null)
 
   const sidebarDrag = useDrag('horizontal', sidebarRef, 180, 600, setSidebarWidth)
-
-  // Read initial sizes once without subscribing — DOM refs own the size during drag.
   const { sidebarWidth, editorHeight } = useUIStore.getState()
 
   return (
     <div className="flex h-screen overflow-hidden bg-th-bg text-th-text-primary">
-      {/* Sidebar */}
       <div
         ref={sidebarRef}
         style={{ width: sidebarWidth ?? 280 }}
@@ -107,78 +132,72 @@ export function AppShell() {
         />
       </div>
 
-      {/* Right pane — drag-region on the wrapper so there's always some
-          drag area; individual views add more via their own headers */}
       <div className="drag-region relative flex flex-1 flex-col overflow-hidden">
         <ErrorBoundary>
-
-        {sidebarTab === 'environments' ? (
-          <div className="no-drag flex flex-1 overflow-hidden">
-            <EnvironmentEditor />
-          </div>
-        ) : selectedItem?.type === 'add-integration' ? (
-          <div className="no-drag flex flex-1 overflow-hidden">
-            <IntegrationSetupPage />
-          </div>
-        ) : selectedItem?.type === 'edit-integration' ? (
-          <div className="no-drag flex flex-1 overflow-hidden">
-            <IntegrationEditPage key={selectedItem.id} integrationId={selectedItem.id} />
-          </div>
-        ) : selectedItem?.type === 'export-page' ? (
-          <div className="no-drag flex flex-1 flex-col overflow-hidden">
-            <ExportPage />
-          </div>
-        ) : selectedItem?.type === 'import-page' ? (
-          <div className="no-drag flex flex-1 flex-col overflow-hidden">
-            <ImportPage />
-          </div>
-        ) : selectedItem?.type === 'git-source' ? (
-          <div className="no-drag flex flex-1 overflow-hidden">
-            <GitSourceView integrationId={selectedItem.id} />
-          </div>
-        ) : selectedItem?.type === 'collection' ? (
-          <div className="no-drag flex min-h-0 flex-1 flex-col overflow-hidden">
-            <CollectionEditor collectionId={selectedItem.id} />
-          </div>
-        ) : selectedItem?.type === 'group' ? (
-          <div className="no-drag flex min-h-0 flex-1 flex-col overflow-hidden">
-            <GroupEditor groupId={selectedItem.id} />
-          </div>
-        ) : selectedItem?.type === 'ai-collection' ? (
-          <div className="no-drag flex flex-1 flex-col overflow-hidden">
-            <AiCollectionPage collectionId={selectedItem.id} />
-          </div>
-        ) : selectedItem?.type === 'ai-group' ? (
-          <div className="no-drag flex flex-1 flex-col overflow-hidden">
-            <AiGroupPage groupId={selectedItem.id} />
-          </div>
-        ) : selectedItem?.type === 'ai-request' ? (
-          <div className="no-drag flex flex-1 flex-col overflow-hidden">
-            <AiRequestPage requestId={selectedItem.id} />
-          </div>
-        ) : (
-          <div className="no-drag flex flex-1 flex-col overflow-hidden">
-            <div ref={editorRef} style={{ height: editorHeight ?? 300 }} className="overflow-hidden">
-              <RequestEditor />
+          {sidebarTab === 'environments' ? (
+            <div className="no-drag flex flex-1 overflow-hidden">
+              <EnvironmentEditor />
             </div>
-            <ResizablePanel
-              direction="vertical"
-              targetRef={editorRef}
-              onCommit={setEditorHeight}
-              minSize={150}
-              maxSize={800}
-            />
-            <div className="flex-1 overflow-hidden">
-              <ResponseViewer />
+          ) : selectedItem?.type === 'add-integration' ? (
+            <div className="no-drag flex flex-1 overflow-hidden">
+              <IntegrationSetupPage />
             </div>
-          </div>
-        )}
+          ) : selectedItem?.type === 'edit-integration' ? (
+            <div className="no-drag flex flex-1 overflow-hidden">
+              <IntegrationEditPage key={selectedItem.id} integrationId={selectedItem.id} />
+            </div>
+          ) : selectedItem?.type === 'export-page' ? (
+            <div className="no-drag flex flex-1 flex-col overflow-hidden">
+              <ExportPage />
+            </div>
+          ) : selectedItem?.type === 'import-page' ? (
+            <div className="no-drag flex flex-1 flex-col overflow-hidden">
+              <ImportPage />
+            </div>
+          ) : selectedItem?.type === 'git-source' ? (
+            <div className="no-drag flex flex-1 overflow-hidden">
+              <GitSourceView integrationId={selectedItem.id} />
+            </div>
+          ) : selectedItem?.type === 'collection' ? (
+            <div className="no-drag flex min-h-0 flex-1 flex-col overflow-hidden">
+              <CollectionEditor collectionId={selectedItem.id} />
+            </div>
+          ) : selectedItem?.type === 'group' ? (
+            <div className="no-drag flex min-h-0 flex-1 flex-col overflow-hidden">
+              <GroupEditor folderId={selectedItem.id} />
+            </div>
+          ) : selectedItem?.type === 'ai-collection' ? (
+            <div className="no-drag flex flex-1 flex-col overflow-hidden">
+              <AiCollectionPage collectionId={selectedItem.id} />
+            </div>
+          ) : selectedItem?.type === 'ai-group' ? (
+            <div className="no-drag flex flex-1 flex-col overflow-hidden">
+              <AiGroupPage folderId={selectedItem.id} />
+            </div>
+          ) : selectedItem?.type === 'ai-request' ? (
+            <div className="no-drag flex flex-1 flex-col overflow-hidden">
+              <AiRequestPage requestId={selectedItem.id} />
+            </div>
+          ) : (
+            <div className="no-drag flex flex-1 flex-col overflow-hidden">
+              <div ref={editorRef} style={{ height: editorHeight ?? 300 }} className="overflow-hidden">
+                <RequestEditor />
+              </div>
+              <ResizablePanel
+                direction="vertical"
+                targetRef={editorRef}
+                onCommit={setEditorHeight}
+                minSize={150}
+                maxSize={800}
+              />
+              <div className="flex-1 overflow-hidden">
+                <ResponseViewer />
+              </div>
+            </div>
+          )}
         </ErrorBoundary>
-        {/* Window controls rendered LAST so no-drag wins over any inner
-            drag-region elements in DOM/paint order. Positioned absolute. */}
         {window.api.platform !== 'darwin' && <WindowControls />}
       </div>
     </div>
   )
 }
-

--- a/src/renderer/src/components/layout/AppShell.tsx
+++ b/src/renderer/src/components/layout/AppShell.tsx
@@ -16,7 +16,7 @@ import { ImportPage } from '@/components/export-import/ImportPage'
 import { WindowControls } from '@/components/layout/WindowControls'
 import { useUIStore } from '@/store/ui'
 import { useCollectionsStore } from '@/store/collections'
-import type { AiContext, } from '@/lib/aiContext'
+import type { AiContext } from '@/lib/aiContext'
 import type { Folder } from '@/types'
 
 function findRootCollection(folderId: string, folders: Folder[]): Folder | undefined {

--- a/src/renderer/src/components/sidebar/CollectionsSidebar.tsx
+++ b/src/renderer/src/components/sidebar/CollectionsSidebar.tsx
@@ -11,7 +11,7 @@ import { useEnvironmentsStore } from '@/store/environments'
 import { useIntegrationsStore } from '@/store/integrations'
 import { useUIStore } from '@/store/ui'
 import { cn } from '@/lib/utils'
-import type { CollectionSource } from '@/types'
+import type { CollectionSource, Folder } from '@/types'
 
 const METHOD_COLORS: Record<string, 'green' | 'yellow' | 'blue' | 'red' | 'orange' | 'purple' | 'grey'> = {
   GET: 'green',
@@ -25,95 +25,94 @@ const METHOD_COLORS: Record<string, 'green' | 'yellow' | 'blue' | 'red' | 'orang
 
 function DragOverlayContent({ id }: { id: string }) {
   const [type, itemId] = id.split(':')
-  const { collections, groups, requests } = useCollectionsStore()
+  const { folders, requests } = useCollectionsStore()
 
   let label = ''
   let badge: React.ReactNode = null
 
   if (type === 'req') {
-    const req = requests.find((r) => r.id === itemId)
+    const req = requests.find((request) => request.id === itemId)
     label = req?.name ?? 'Request'
     badge = <Badge variant={METHOD_COLORS[req?.method ?? ''] ?? 'grey'} className="shrink-0 font-mono text-[10px]">{req?.method ?? 'GET'}</Badge>
-  } else if (type === 'grp') {
-    label = groups.find((g) => g.id === itemId)?.name ?? 'Group'
-  } else if (type === 'col') {
-    label = collections.find((c) => c.id === itemId)?.name ?? 'Collection'
+  } else if (type === 'fld') {
+    const folder = folders.find((item) => item.id === itemId)
+    label = folder?.name ?? 'Folder'
   }
 
   return (
-    <div className="flex items-center gap-2 rounded-sm border border-blue-500/50 bg-th-surface-raised px-3 py-1.5 text-sm text-th-text-primary shadow-lg opacity-90">
+    <div className="flex items-center gap-2 rounded-sm border border-blue-500/50 bg-th-surface-raised px-3 py-1.5 text-sm text-th-text-primary opacity-90 shadow-lg">
       {badge}
-      <span className="truncate max-w-48">{label}</span>
+      <span className="max-w-48 truncate">{label}</span>
     </div>
   )
 }
 
-function handleDragEnd(event: DragEndEvent) {
+function isDescendant(candidateParentId: string, folderId: string, folders: Folder[]): boolean {
+  let current = folders.find((folder) => folder.id === candidateParentId)
+  while (current?.parentId) {
+    if (current.parentId === folderId) return true
+    current = folders.find((folder) => folder.id === current?.parentId)
+  }
+  return current?.id === folderId
+}
+
+async function handleDragEnd(event: DragEndEvent) {
   const { active, over } = event
   if (!over || active.id === over.id) return
 
-  const activeStr = String(active.id)
-  const overStr = String(over.id)
+  const [activeType, activeId] = String(active.id).split(':') as [string, string]
+  const [overType, overId] = String(over.id).split(':') as [string, string]
 
-  const [activeType, activeId] = activeStr.split(':') as [string, string]
-  const [overType, overId] = overStr.split(':') as [string, string]
-
-  const { collections, groups, requests, moveRequestToGroup, moveGroupToCollection, moveCollectionToSource } = useCollectionsStore.getState()
+  const { folders, requests, moveRequestToFolder, moveFolder, moveCollectionToSource } = useCollectionsStore.getState()
 
   if (activeType === 'req') {
-    const activeReq = requests.find((r) => r.id === activeId)
+    const activeReq = requests.find((request) => request.id === activeId)
     if (!activeReq) return
 
     if (overType === 'req') {
-      const overReq = requests.find((r) => r.id === overId)
+      const overReq = requests.find((request) => request.id === overId)
       if (!overReq) return
-      // Determine insert position based on drag direction
-      const sortedGroupReqs = requests
-        .filter((r) => r.groupId === overReq.groupId)
+      const sortedFolderRequests = requests
+        .filter((request) => request.folderId === overReq.folderId)
         .sort((a, b) => a.sortOrder - b.sortOrder)
-      const activeIdx = sortedGroupReqs.findIndex((r) => r.id === activeId)
-      const overIdx = sortedGroupReqs.findIndex((r) => r.id === overId)
-      // Dragging down: insert after over item (before the item after it)
+      const activeIdx = sortedFolderRequests.findIndex((request) => request.id === activeId)
+      const overIdx = sortedFolderRequests.findIndex((request) => request.id === overId)
       const insertBeforeId = activeIdx < overIdx
-        ? sortedGroupReqs[overIdx + 1]?.id ?? null
+        ? sortedFolderRequests[overIdx + 1]?.id ?? null
         : overReq.id
-      moveRequestToGroup(activeId, overReq.groupId, insertBeforeId)
-    } else if (overType === 'grp') {
-      moveRequestToGroup(activeId, overId, null)
+      await moveRequestToFolder(activeId, overReq.folderId, insertBeforeId)
+    } else if (overType === 'fld') {
+      await moveRequestToFolder(activeId, overId, null)
     }
-  } else if (activeType === 'grp') {
-    const activeGrp = groups.find((g) => g.id === activeId)
-    if (!activeGrp) return
+    return
+  }
 
-    if (overType === 'grp') {
-      const overGrp = groups.find((g) => g.id === overId)
-      if (!overGrp) return
-      const sortedColGroups = groups
-        .filter((g) => g.collectionId === overGrp.collectionId)
-        .sort((a, b) => a.sortOrder - b.sortOrder)
-      const activeIdx = sortedColGroups.findIndex((g) => g.id === activeId)
-      const overIdx = sortedColGroups.findIndex((g) => g.id === overId)
-      const insertBeforeId = activeIdx < overIdx
-        ? sortedColGroups[overIdx + 1]?.id ?? null
-        : overGrp.id
-      moveGroupToCollection(activeId, overGrp.collectionId, insertBeforeId)
-    } else if (overType === 'col') {
-      moveGroupToCollection(activeId, overId, null)
-    }
-  } else if (activeType === 'col') {
-    if (overType === 'col') {
-      const overCol = collections.find((c) => c.id === overId)
-      if (!overCol) return
-      moveCollectionToSource(activeId, overCol.source as CollectionSource)
+  if (activeType === 'fld' && overType === 'fld') {
+    const activeFolder = folders.find((folder) => folder.id === activeId)
+    const overFolder = folders.find((folder) => folder.id === overId)
+    if (!activeFolder || !overFolder) return
+    if (isDescendant(overFolder.id, activeFolder.id, folders)) return
+
+    const targetParentId = overFolder.parentId ?? null
+    const siblings = folders
+      .filter((folder) => (folder.parentId ?? null) === targetParentId)
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+    const activeIdx = siblings.findIndex((folder) => folder.id === activeId)
+    const overIdx = siblings.findIndex((folder) => folder.id === overId)
+    const insertBeforeId = activeIdx < overIdx ? siblings[overIdx + 1]?.id ?? null : overFolder.id
+
+    await moveFolder(activeId, targetParentId, insertBeforeId)
+    if (!activeFolder.parentId && !overFolder.parentId && activeFolder.source !== overFolder.source) {
+      await moveCollectionToSource(activeId, overFolder.source as CollectionSource)
     }
   }
 }
 
 export function CollectionsSidebar() {
-  const { collections, groups, requests, searchQuery, load } = useCollectionsStore()
+  const { folders, requests, searchQuery, load } = useCollectionsStore()
   const { integrations, load: loadIntegrations } = useIntegrationsStore()
   const { load: loadEnvironments } = useEnvironmentsStore()
-  const selectItem = useUIStore((s) => s.selectItem)
+  const selectItem = useUIStore((state) => state.selectItem)
   const { openSettings, sidebarTab, setSidebarTab } = useUIStore()
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
@@ -121,15 +120,13 @@ export function CollectionsSidebar() {
   const [dragOverId, setDragOverId] = useState<string | null>(null)
 
   useEffect(() => {
-    load()
-    loadIntegrations()
-    loadEnvironments()
+    void load()
+    void loadIntegrations()
+    void loadEnvironments()
   }, [load, loadIntegrations, loadEnvironments])
 
   return (
     <div data-testid="sidebar" className="flex h-full flex-col bg-th-bg">
-
-      {/* Tab switcher — pt-8 on macOS clears the hiddenInset traffic lights */}
       <div className={cn('flex shrink-0 border-b border-th-border', window.api.platform === 'darwin' && 'pt-8')}>
         <button
           data-testid="tab-apis"
@@ -159,103 +156,96 @@ export function CollectionsSidebar() {
         </button>
       </div>
 
-      {/* ── APIs tab ─────────────────────────────────────────────────────── */}
       {sidebarTab === 'apis' && (
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragStart={({ active }) => { setDragActiveId(String(active.id)); setDragOverId(null) }}
           onDragOver={({ over }: DragOverEvent) => setDragOverId(over ? String(over.id) : null)}
-          onDragEnd={(event) => { setDragActiveId(null); setDragOverId(null); handleDragEnd(event) }}
+          onDragEnd={(event) => { setDragActiveId(null); setDragOverId(null); void handleDragEnd(event) }}
           onDragCancel={() => { setDragActiveId(null); setDragOverId(null) }}
         >
-        <>
-          <div className="shrink-0 p-2">
-            <SidebarSearch />
-          </div>
+          <>
+            <div className="shrink-0 p-2">
+              <SidebarSearch />
+            </div>
 
-          {/* Scrollable tree */}
-          <div className="flex-1 overflow-y-auto py-1">
-            <GroupSection
-              source="local"
-              integration={null}
-              collections={collections}
-              groups={groups}
-              requests={requests}
-              searchQuery={searchQuery}
-              dragActiveId={dragActiveId}
-              dragOverId={dragOverId}
-            />
-
-            {integrations.map((integration) => (
+            <div className="flex-1 overflow-y-auto py-1">
               <GroupSection
-                key={integration.id}
-                source={integration.type}
-                integration={integration}
-                collections={collections}
-                groups={groups}
+                source="local"
+                integration={null}
+                folders={folders}
                 requests={requests}
                 searchQuery={searchQuery}
                 dragActiveId={dragActiveId}
                 dragOverId={dragOverId}
               />
-            ))}
 
-            {/* Connect source row — lives in the tree so context is clear */}
-            <div className="mx-2 mt-2 mb-1">
-              <button
-                onClick={() => selectItem('add-integration', '')}
-                className="flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-th-surface-raised focus:outline-hidden group"
-              >
-                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border border-dashed border-th-border-strong text-th-text-faint group-hover:border-th-text-muted group-hover:text-th-text-subtle">
-                  <Link className="h-3 w-3" />
-                </span>
-                <span className="flex flex-col">
-                  <span className="text-xs text-th-text-subtle group-hover:text-th-text-secondary">Connect a source</span>
-                  <span className="text-[10px] text-th-text-faint">Git · Backstage · GitHub · GitLab</span>
-                </span>
-              </button>
+              {integrations.map((integration) => (
+                <GroupSection
+                  key={integration.id}
+                  source={integration.type}
+                  integration={integration}
+                  folders={folders}
+                  requests={requests}
+                  searchQuery={searchQuery}
+                  dragActiveId={dragActiveId}
+                  dragOverId={dragOverId}
+                />
+              ))}
+
+              <div className="mx-2 mb-1 mt-2">
+                <button
+                  onClick={() => selectItem('add-integration', '')}
+                  className="group flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-th-surface-raised focus:outline-hidden"
+                >
+                  <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm border border-dashed border-th-border-strong text-th-text-faint group-hover:border-th-text-muted group-hover:text-th-text-subtle">
+                    <Link className="h-3 w-3" />
+                  </span>
+                  <span className="flex flex-col">
+                    <span className="text-xs text-th-text-subtle group-hover:text-th-text-secondary">Connect a source</span>
+                    <span className="text-[10px] text-th-text-faint">Git · Backstage · GitHub · GitLab</span>
+                  </span>
+                </button>
+              </div>
             </div>
-          </div>
 
-          {/* APIs footer — always visible */}
-          <div className="shrink-0 border-t border-th-border">
-            <div data-testid="sidebar-footer" className="flex items-center gap-1 px-2 py-2">
-              <button
-                data-testid="btn-export"
-                onClick={() => selectItem('export-page', '')}
-                className="rounded-sm p-1.5 text-th-text-subtle hover:bg-th-surface-raised hover:text-th-text-secondary focus:outline-hidden"
-                title="Export collections"
-              >
-                <Download className="h-4 w-4" />
-              </button>
-              <button
-                data-testid="btn-import"
-                onClick={() => selectItem('import-page', '')}
-                className="rounded-sm p-1.5 text-th-text-subtle hover:bg-th-surface-raised hover:text-th-text-secondary focus:outline-hidden"
-                title="Import collections"
-              >
-                <Upload className="h-4 w-4" />
-              </button>
-              <button
-                data-testid="btn-settings"
-                onClick={() => openSettings()}
-                className="ml-auto rounded-sm p-1.5 text-th-text-subtle hover:bg-th-surface-raised hover:text-th-text-secondary focus:outline-hidden"
-                title="Settings"
-              >
-                <Settings className="h-4 w-4" />
-              </button>
+            <div className="shrink-0 border-t border-th-border">
+              <div data-testid="sidebar-footer" className="flex items-center gap-1 px-2 py-2">
+                <button
+                  data-testid="btn-export"
+                  onClick={() => selectItem('export-page', '')}
+                  className="rounded-sm p-1.5 text-th-text-subtle hover:bg-th-surface-raised hover:text-th-text-secondary focus:outline-hidden"
+                  title="Export collections"
+                >
+                  <Download className="h-4 w-4" />
+                </button>
+                <button
+                  data-testid="btn-import"
+                  onClick={() => selectItem('import-page', '')}
+                  className="rounded-sm p-1.5 text-th-text-subtle hover:bg-th-surface-raised hover:text-th-text-secondary focus:outline-hidden"
+                  title="Import collections"
+                >
+                  <Upload className="h-4 w-4" />
+                </button>
+                <button
+                  data-testid="btn-settings"
+                  onClick={() => openSettings()}
+                  className="ml-auto rounded-sm p-1.5 text-th-text-subtle hover:bg-th-surface-raised hover:text-th-text-secondary focus:outline-hidden"
+                  title="Settings"
+                >
+                  <Settings className="h-4 w-4" />
+                </button>
+              </div>
             </div>
-          </div>
 
-          <DragOverlay dropAnimation={null}>
-            {dragActiveId ? <DragOverlayContent id={dragActiveId} /> : null}
-          </DragOverlay>
-        </>
+            <DragOverlay dropAnimation={null}>
+              {dragActiveId ? <DragOverlayContent id={dragActiveId} /> : null}
+            </DragOverlay>
+          </>
         </DndContext>
       )}
 
-      {/* ── Environments tab ──────────────────────────────────────────────── */}
       {sidebarTab === 'environments' && (
         <div className="flex flex-1 flex-col overflow-hidden">
           <EnvironmentsPanel />
@@ -264,4 +254,3 @@ export function CollectionsSidebar() {
     </div>
   )
 }
-

--- a/src/renderer/src/components/sidebar/GroupSection.tsx
+++ b/src/renderer/src/components/sidebar/GroupSection.tsx
@@ -1,9 +1,9 @@
 import * as Collapsible from '@radix-ui/react-collapsible'
-import { AlertCircle, Check, ChevronDown, ChevronRight, Database, Eye, EyeOff, FolderOpen, GitBranch, GitFork, GripVertical, MoreHorizontal, Pencil, Plus, Settings, Trash2, X } from 'lucide-react'
-import React, { useRef, useState } from 'react'
+import { AlertCircle, Check, ChevronDown, ChevronRight, Database, Eye, EyeOff, FolderOpen, FolderPlus, GitBranch, GitFork, GripVertical, MoreHorizontal, Pencil, Plus, Settings, Trash2, X } from 'lucide-react'
+import React, { useMemo, useRef, useState } from 'react'
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import type { Collection, CollectionSource, Group, Integration, Request } from '@/types'
+import type { CollectionSource, Folder, Integration, Request } from '@/types'
 import { AiActionButton } from '@/components/ai/AiActionButton'
 import { RequestTreeItem } from '@/components/sidebar/RequestTreeItem'
 import { Badge } from '@/components/ui/Badge'
@@ -28,251 +28,176 @@ function capitalize(s: string) {
 interface GroupSectionProps {
   source: CollectionSource
   integration?: Integration | null
-  collections: Collection[]
-  groups: Group[]
+  folders: Folder[]
   requests: Request[]
   searchQuery: string
   dragActiveId?: string | null
   dragOverId?: string | null
 }
-
-// ─── Inline input helper ──────────────────────────────────────────────────────
 
 interface InlineInputProps {
   placeholder: string
   onConfirm: (name: string) => void
   onCancel: () => void
-  indent?: string
+  paddingLeft?: number
 }
 
-function InlineInput({ placeholder, onConfirm, onCancel, indent = 'pl-4' }: InlineInputProps) {
-  const [val, setVal] = useState('')
+function InlineInput({ placeholder, onConfirm, onCancel, paddingLeft = 16 }: InlineInputProps) {
+  const [value, setValue] = useState('')
   const ref = useRef<HTMLInputElement>(null)
   React.useEffect(() => { ref.current?.focus() }, [])
 
   return (
-    <div className={cn('flex items-center gap-1 py-0.5 pr-2', indent)}>
+    <div className="flex items-center gap-1 py-0.5 pr-2" style={{ paddingLeft }}>
       <input
         ref={ref}
-        value={val}
-        onChange={(e) => setVal(e.target.value)}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') { if (val.trim()) onConfirm(val.trim()); else onCancel() }
+          if (e.key === 'Enter') { if (value.trim()) onConfirm(value.trim()); else onCancel() }
           if (e.key === 'Escape') onCancel()
         }}
         placeholder={placeholder}
         className="flex-1 rounded-sm bg-th-surface-raised px-2 py-1 text-sm text-th-text-primary placeholder-th-text-subtle outline-hidden ring-1 ring-blue-500/50"
       />
-      <button onClick={() => { if (val.trim()) onConfirm(val.trim()); else onCancel() }} className="text-green-400 hover:text-green-300"><Check className="h-3.5 w-3.5" /></button>
+      <button onClick={() => { if (value.trim()) onConfirm(value.trim()); else onCancel() }} className="text-green-400 hover:text-green-300"><Check className="h-3.5 w-3.5" /></button>
       <button onClick={onCancel} className="text-th-text-subtle hover:text-th-text-secondary"><X className="h-3.5 w-3.5" /></button>
     </div>
   )
 }
 
-// ─── Collection row ───────────────────────────────────────────────────────────
-
-interface CollectionRowProps {
-  collection: Collection
-  open: boolean
-  onToggle: () => void
-  onAddRequest: () => void
-  onAddGroup: () => void
-  onRename: () => void
-  onDelete: () => void
-  dndId: string
+function getRootCollection(folderId: string, folders: Folder[]): Folder | undefined {
+  let current = folders.find((folder) => folder.id === folderId)
+  while (current?.parentId) {
+    current = folders.find((folder) => folder.id === current?.parentId)
+  }
+  return current
 }
 
-function CollectionRow({ collection, open, onToggle, onSelect, onAddRequest, onAddGroup, onRename, onDelete, isActive, onAi, dndId }: CollectionRowProps & { isActive?: boolean; onSelect: () => void; onAi: () => void }) {
-  const [menuOpen, setMenuOpen] = useState(false)
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: dndId })
-  const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }
-  const isDirty = useUIStore((s) => s.dirtyEditors.has(collection.id))
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={cn(
-        'group relative flex items-center gap-1 rounded-sm px-2 py-0.5 text-th-text-muted hover:text-th-text-primary',
-        isActive ? 'bg-th-surface-hover text-th-text-primary' : 'hover:bg-th-surface-raised/60'
-      )}
-    >
-      <button
-        {...listeners}
-        {...attributes}
-        className="cursor-grab shrink-0 rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover:opacity-100 active:cursor-grabbing"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <GripVertical className="h-3.5 w-3.5" />
-      </button>
-
-      {/* Chevron — expand/collapse only */}
-      <button
-        data-testid={`collection-toggle-${collection.id}`}
-        onClick={(e) => { e.stopPropagation(); onToggle() }}
-        className="shrink-0 rounded-sm p-0.5 focus:outline-hidden"
-      >
-        {open ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-      </button>
-
-      {/* Name — select only */}
-      <button
-        onClick={onSelect}
-        className={cn(
-          'flex flex-1 items-center gap-1.5 truncate rounded-sm px-1 py-1 text-left text-sm font-semibold focus:outline-hidden',
-          isActive ? 'text-th-text-primary' : 'text-th-text-muted hover:text-th-text-primary'
-        )}
-      >
-        <span className="truncate">{collection.name}</span>
-        {isDirty && <span data-testid="collection-dirty-dot" className="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" title="Unsaved changes" />}
-      </button>
-
-      {/* hover actions */}
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-        <button
-          title="Add request"
-          onClick={(e) => { e.stopPropagation(); onAddRequest() }}
-          className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden"
-        >
-          <Plus className="h-3.5 w-3.5" />
-        </button>
-        <button
-          title="Add group"
-          onClick={(e) => { e.stopPropagation(); onAddGroup() }}
-          className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden"
-        >
-          <FolderOpen className="h-3.5 w-3.5" />
-        </button>
-        <button
-          title="More"
-          onClick={(e) => { e.stopPropagation(); setMenuOpen(!menuOpen) }}
-          className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden"
-        >
-          <MoreHorizontal className="h-3.5 w-3.5" />
-        </button>
-      </div>
-
-      {menuOpen && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
-          <div className="absolute right-0 top-full z-20 mt-1 w-40 overflow-hidden rounded-sm border border-th-border-strong bg-th-surface-raised shadow-lg">
-            <AiActionButton
-              variant="menu-item"
-              onClick={() => { setMenuOpen(false); onAi() }}
-            />
-            <div className="border-t border-th-border mx-2" />
-            <button
-              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-th-text-primary hover:bg-th-surface-hover"
-              onClick={(e) => { e.stopPropagation(); setMenuOpen(false); onRename() }}
-            >
-              <Pencil className="h-3.5 w-3.5" /> Rename
-            </button>
-            <button
-              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-rose-400 hover:bg-th-surface-hover"
-              onClick={(e) => { e.stopPropagation(); setMenuOpen(false); onDelete() }}
-            >
-              <Trash2 className="h-3.5 w-3.5" /> Delete
-            </button>
-          </div>
-        </>
-      )}
-    </div>
-  )
+function subtreeMatches(folder: Folder, folders: Folder[], requests: Request[], query: string): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  if (folder.name.toLowerCase().includes(q) || (folder.description ?? '').toLowerCase().includes(q)) return true
+  if (requests.some((request) => request.folderId === folder.id && (`${request.name} ${request.url}`.toLowerCase().includes(q)))) return true
+  return folders
+    .filter((child) => child.parentId === folder.id)
+    .some((child) => subtreeMatches(child, folders, requests, query))
 }
 
-// ─── Sortable group row ───────────────────────────────────────────────────────
-
-interface SortableGroupRowProps {
-  group: Group
+interface FolderTreeRowProps {
+  folder: Folder
+  depth: number
+  allFolders: Folder[]
   requests: Request[]
   searchQuery: string
-  renamingGroup: string | null
-  groupMenuOpen: string | null
-  selectedItem: { type: string; id: string } | null
-  onRenameConfirm: (name: string) => void
-  onRenameCancel: () => void
-  onSelect: () => void
-  onAddRequest: () => void
-  onMenuToggle: () => void
-  onMenuClose: () => void
-  onRenameStart: () => void
-  onDelete: () => void
-  onAiGroup: () => void
-  onDeleteRequest: (reqId: string) => void
-  onClickRequest: (req: Request) => void
-  activeRequestId: string | null
   dragActiveId?: string | null
   dragOverId?: string | null
+  renamingFolderId: string | null
+  folderMenuOpen: string | null
+  addingFolderTo: string | null
+  addingRequestTo: string | null
+  onRenameStart: (folderId: string) => void
+  onRenameCancel: () => void
+  onRenameConfirm: (folder: Folder, name: string) => void
+  onMenuToggle: (folderId: string) => void
+  onMenuClose: () => void
+  onAddFolderStart: (folderId: string) => void
+  onAddFolderCancel: () => void
+  onAddFolderConfirm: (parent: Folder, name: string) => void
+  onAddRequest: (folder: Folder) => void
+  onDeleteFolder: (folder: Folder) => void
+  onDeleteRequest: (folder: Folder, requestId: string) => void
 }
 
-function SortableGroupRow({
-  group, requests, searchQuery, renamingGroup, groupMenuOpen, selectedItem,
-  onRenameConfirm, onRenameCancel, onSelect, onAddRequest, onMenuToggle,
-  onMenuClose, onRenameStart, onDelete, onAiGroup, onDeleteRequest, onClickRequest, activeRequestId,
-  dragActiveId, dragOverId,
-}: SortableGroupRowProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: `grp:${group.id}` })
-  const grpStyle = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }
-  const isDirtyGroup = useUIStore((s) => s.dirtyEditors.has(group.id))
+function FolderTreeRow({
+  folder,
+  depth,
+  allFolders,
+  requests,
+  searchQuery,
+  dragActiveId,
+  dragOverId,
+  renamingFolderId,
+  folderMenuOpen,
+  addingFolderTo,
+  addingRequestTo,
+  onRenameStart,
+  onRenameCancel,
+  onRenameConfirm,
+  onMenuToggle,
+  onMenuClose,
+  onAddFolderStart,
+  onAddFolderCancel,
+  onAddFolderConfirm,
+  onAddRequest,
+  onDeleteFolder,
+  onDeleteRequest,
+}: FolderTreeRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: `fld:${folder.id}` })
+  const style = { transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }
+  const toggleFolderCollapsed = useCollectionsStore((state) => state.toggleFolderCollapsed)
+  const { activeRequestId, setActiveRequest, clearActiveRequest } = useRequestsStore()
+  const { selectItem, clearSelectedItem, selectedItem } = useUIStore()
+  const isDirty = useUIStore((state) => state.dirtyEditors.has(folder.id))
 
-  const filteredReqs = requests
-    .filter((r) => {
-      const q = searchQuery.toLowerCase()
-      return r.groupId === group.id && (!q || r.name.toLowerCase().includes(q) || r.url.toLowerCase().includes(q))
-    })
+  const children = allFolders
+    .filter((child) => child.parentId === folder.id)
+    .filter((child) => subtreeMatches(child, allFolders, requests, searchQuery))
     .sort((a, b) => a.sortOrder - b.sortOrder)
-  if (searchQuery && filteredReqs.length === 0) return null
+  const folderRequests = requests
+    .filter((request) => request.folderId === folder.id && (!searchQuery || `${request.name} ${request.url}`.toLowerCase().includes(searchQuery.toLowerCase())))
+    .sort((a, b) => a.sortOrder - b.sortOrder)
 
-  // Determine if a foreign request is being dragged over this group
+  if (searchQuery && !subtreeMatches(folder, allFolders, requests, searchQuery)) return null
+
+  const isRoot = !folder.parentId
+  const isOpen = !folder.collapsed || !!searchQuery
+  const isSelected = selectedItem?.id === folder.id && selectedItem.type === (isRoot ? 'collection' : 'group')
+
   const activeReqId = dragActiveId?.startsWith('req:') ? dragActiveId.slice(4) : null
-  const activeReq = activeReqId ? requests.find((r) => r.id === activeReqId) : null
-  const isExternalReqDrag = !!activeReq && activeReq.groupId !== group.id
-  const overIsThisGroup = dragOverId === `grp:${group.id}` ||
-    filteredReqs.some((r) => dragOverId === `req:${r.id}`)
-  const isGroupDropTarget = isExternalReqDrag && overIsThisGroup
+  const activeReq = activeReqId ? requests.find((request) => request.id === activeReqId) : null
+  const isExternalReqDrag = !!activeReq && activeReq.folderId !== folder.id
+  const overIsThisFolder = dragOverId === `fld:${folder.id}` || folderRequests.some((request) => dragOverId === `req:${request.id}`)
+  const showDropTarget = isExternalReqDrag && overIsThisFolder
 
-  // Compute insertion line positions for within-same-group reorder
   const overReqId = dragOverId?.startsWith('req:') ? dragOverId.slice(4) : null
-  const isSameGroupDrag = !!activeReqId && activeReq?.groupId === group.id
+  const isSameFolderDrag = !!activeReqId && activeReq?.folderId === folder.id
   let insertLineAboveId: string | null = null
   let insertLineBelowId: string | null = null
-  if (isSameGroupDrag && overReqId) {
-    const activeIdx = filteredReqs.findIndex((r) => r.id === activeReqId)
-    const overIdx = filteredReqs.findIndex((r) => r.id === overReqId)
+  if (isSameFolderDrag && overReqId) {
+    const activeIdx = folderRequests.findIndex((request) => request.id === activeReqId)
+    const overIdx = folderRequests.findIndex((request) => request.id === overReqId)
     if (activeIdx !== -1 && overIdx !== -1 && activeIdx !== overIdx) {
-      if (activeIdx < overIdx) {
-        // dragging down — line appears below the over item
-        insertLineBelowId = overReqId
-      } else {
-        // dragging up — line appears above the over item
-        insertLineAboveId = overReqId
-      }
+      if (activeIdx < overIdx) insertLineBelowId = overReqId
+      else insertLineAboveId = overReqId
     }
   }
 
+  const rowPadding = isRoot ? 8 : 8 + depth * 16
+
   return (
-    <div ref={setNodeRef} style={grpStyle}>
-      <Collapsible.Root
-        open={!group.collapsed || !!searchQuery}
-        onOpenChange={() => useCollectionsStore.getState().toggleGroupCollapsed(group.id)}
-      >
-        {renamingGroup === group.id ? (
-          <InlineInput
-            placeholder={group.name}
-            onConfirm={onRenameConfirm}
-            onCancel={onRenameCancel}
-            indent="pl-2"
-          />
-        ) : (
-          <div className={cn(
-            'group/grp relative flex items-center gap-1 rounded-sm px-2 py-0.5 text-th-text-muted hover:text-th-text-primary',
-            selectedItem?.type === 'group' && selectedItem.id === group.id
-              ? 'bg-th-surface-hover text-th-text-primary'
-              : 'hover:bg-th-surface-raised/60'
-          )}>
+    <div ref={setNodeRef} style={style}>
+      {renamingFolderId === folder.id ? (
+        <InlineInput
+          placeholder={folder.name}
+          paddingLeft={rowPadding}
+          onConfirm={(name) => onRenameConfirm(folder, name)}
+          onCancel={onRenameCancel}
+        />
+      ) : (
+        <Collapsible.Root open={isOpen} onOpenChange={() => toggleFolderCollapsed(folder.id)}>
+          <div
+            className={cn(
+              'group relative flex items-center gap-1 rounded-sm px-2 py-0.5 text-th-text-muted hover:text-th-text-primary',
+              isSelected ? 'bg-th-surface-hover text-th-text-primary' : 'hover:bg-th-surface-raised/60',
+              showDropTarget && 'ring-1 ring-blue-500/40 bg-blue-500/5'
+            )}
+            style={{ paddingLeft: rowPadding }}
+          >
             <button
-              {...listeners} {...attributes}
-              className="cursor-grab shrink-0 rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/grp:opacity-100 active:cursor-grabbing"
+              {...listeners}
+              {...attributes}
+              className="cursor-grab shrink-0 rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover:opacity-100 active:cursor-grabbing"
               onClick={(e) => e.stopPropagation()}
             >
               <GripVertical className="h-3.5 w-3.5" />
@@ -280,150 +205,248 @@ function SortableGroupRow({
 
             <Collapsible.Trigger asChild>
               <button className="shrink-0 rounded-sm p-0.5 focus:outline-hidden" onClick={(e) => e.stopPropagation()}>
-                {group.collapsed ? <ChevronRight className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                {isOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
               </button>
             </Collapsible.Trigger>
 
             <button
-              onClick={onSelect}
+              onClick={() => selectItem(isRoot ? 'collection' : 'group', folder.id)}
               className={cn(
                 'flex flex-1 items-center gap-1.5 truncate rounded-sm py-1 text-left text-sm font-semibold focus:outline-hidden',
-                selectedItem?.type === 'group' && selectedItem.id === group.id
-                  ? 'text-th-text-primary' : 'text-th-text-muted hover:text-th-text-primary',
-                group.hidden && 'opacity-50'
+                isSelected ? 'text-th-text-primary' : 'text-th-text-muted hover:text-th-text-primary',
+                folder.hidden && 'opacity-50'
               )}
             >
-              <span className="truncate">{group.name}</span>
-              {isDirtyGroup && <span data-testid="group-dirty-dot" className="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" title="Unsaved changes" />}
-              {group.hidden && <EyeOff className="ml-auto h-3 w-3 shrink-0" />}
+              {isRoot ? <FolderOpen className="h-3.5 w-3.5 shrink-0" /> : <FolderPlus className="h-3.5 w-3.5 shrink-0" />}
+              <span className="truncate">{folder.name}</span>
+              {isRoot && <Badge variant="grey" className="ml-1">{folder.source}</Badge>}
+              {isDirty && <span data-testid="group-dirty-dot" className="h-1.5 w-1.5 shrink-0 rounded-full bg-orange-500" title="Unsaved changes" />}
+              {folder.hidden && <EyeOff className="ml-auto h-3 w-3 shrink-0" />}
             </button>
 
-            <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/grp:opacity-100">
-              <button title="Add request" onClick={onAddRequest} className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden">
+            <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+              <button title="Add request" onClick={() => onAddRequest(folder)} className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden">
                 <Plus className="h-3.5 w-3.5" />
               </button>
-              <button title="More" onClick={(e) => { e.stopPropagation(); onMenuToggle() }} className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden">
+              <button title="Add folder" onClick={() => onAddFolderStart(folder.id)} className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden">
+                <FolderPlus className="h-3.5 w-3.5" />
+              </button>
+              <button title="More" onClick={(e) => { e.stopPropagation(); onMenuToggle(folder.id) }} className="rounded-sm p-0.5 hover:bg-th-surface-hover focus:outline-hidden">
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </button>
             </div>
 
-            {groupMenuOpen === group.id && (
+            {folderMenuOpen === folder.id && (
               <>
                 <div className="fixed inset-0 z-10" onClick={onMenuClose} />
                 <div className="absolute right-0 top-full z-20 mt-1 w-40 overflow-hidden rounded-sm border border-th-border-strong bg-th-surface-raised shadow-lg">
-                  <AiActionButton variant="menu-item" onClick={() => { onMenuClose(); onAiGroup() }} />
-                  <div className="border-t border-th-border mx-2" />
-                  <button className="flex w-full items-center gap-2 px-3 py-2 text-sm text-th-text-primary hover:bg-th-surface-hover"
-                    onClick={(e) => { e.stopPropagation(); onMenuClose(); onRenameStart() }}>
+                  <AiActionButton variant="menu-item" onClick={() => { onMenuClose(); selectItem(isRoot ? 'ai-collection' : 'ai-group', folder.id) }} />
+                  <div className="mx-2 border-t border-th-border" />
+                  <button className="flex w-full items-center gap-2 px-3 py-2 text-sm text-th-text-primary hover:bg-th-surface-hover" onClick={() => { onMenuClose(); onRenameStart(folder.id) }}>
                     <Pencil className="h-3.5 w-3.5" /> Rename
                   </button>
-                  <button className="flex w-full items-center gap-2 px-3 py-2 text-sm text-rose-400 hover:bg-th-surface-hover"
-                    onClick={(e) => { e.stopPropagation(); onMenuClose(); onDelete() }}>
+                  <button className="flex w-full items-center gap-2 px-3 py-2 text-sm text-rose-400 hover:bg-th-surface-hover" onClick={() => { onMenuClose(); onDeleteFolder(folder) }}>
                     <Trash2 className="h-3.5 w-3.5" /> Delete
                   </button>
                 </div>
               </>
             )}
           </div>
-        )}
 
-        <Collapsible.Content>
-          <div className={cn('pl-1 rounded-sm transition-colors', isGroupDropTarget && 'ring-1 ring-blue-500/40 bg-blue-500/5')}>
-            {filteredReqs.length === 0 && !searchQuery && (
-              <div className="mx-2 my-1.5 rounded-sm border border-dashed border-th-border px-2 py-2 text-center">
-                <p className="text-xs text-th-text-faint">No endpoints defined</p>
-                <p className="mt-0.5 text-xs text-th-text-muted">Use + to add one</p>
-              </div>
-            )}
-            <SortableContext items={filteredReqs.map((r) => `req:${r.id}`)} strategy={verticalListSortingStrategy}>
-              {filteredReqs.map((req) => (
-                <RequestTreeItem
-                  key={req.id}
-                  dndId={`req:${req.id}`}
-                  request={req}
-                  isActive={req.id === activeRequestId && !selectedItem}
-                  insertLine={insertLineAboveId === req.id ? 'above' : insertLineBelowId === req.id ? 'below' : null}
-                  onClick={() => onClickRequest(req)}
-                  onDelete={() => onDeleteRequest(req.id)}
+          <Collapsible.Content>
+            <div>
+              {folderRequests.length === 0 && children.length === 0 && !addingFolderTo && !addingRequestTo && !searchQuery && (
+                <div className="mx-2 my-1.5 rounded-sm border border-dashed border-th-border px-2 py-2 text-center" style={{ marginLeft: rowPadding + 28 }}>
+                  <p className="text-xs text-th-text-faint">Folder is empty</p>
+                  <p className="mt-0.5 text-xs text-th-text-muted">Use + to add content</p>
+                </div>
+              )}
+
+              {addingFolderTo === folder.id && (
+                <InlineInput
+                  placeholder="Folder name…"
+                  paddingLeft={rowPadding + 32}
+                  onConfirm={(name) => onAddFolderConfirm(folder, name)}
+                  onCancel={onAddFolderCancel}
                 />
-              ))}
-            </SortableContext>
-          </div>
-        </Collapsible.Content>
-      </Collapsible.Root>
+              )}
+
+              <SortableContext items={folderRequests.map((request) => `req:${request.id}`)} strategy={verticalListSortingStrategy}>
+                {folderRequests.map((request) => (
+                  <div key={request.id} style={{ paddingLeft: rowPadding + 28 }}>
+                    <RequestTreeItem
+                      dndId={`req:${request.id}`}
+                      request={request}
+                      isActive={request.id === activeRequestId && !selectedItem}
+                      insertLine={insertLineAboveId === request.id ? 'above' : insertLineBelowId === request.id ? 'below' : null}
+                      onClick={() => { clearSelectedItem(); setActiveRequest(request) }}
+                      onDelete={() => {
+                        onDeleteRequest(folder, request.id)
+                        if (activeRequestId === request.id) clearActiveRequest()
+                      }}
+                    />
+                  </div>
+                ))}
+              </SortableContext>
+
+              <SortableContext items={children.map((child) => `fld:${child.id}`)} strategy={verticalListSortingStrategy}>
+                {children.map((child) => (
+                  <FolderTreeRow
+                    key={child.id}
+                    folder={child}
+                    depth={depth + 1}
+                    allFolders={allFolders}
+                    requests={requests}
+                    searchQuery={searchQuery}
+                    dragActiveId={dragActiveId}
+                    dragOverId={dragOverId}
+                    renamingFolderId={renamingFolderId}
+                    folderMenuOpen={folderMenuOpen}
+                    addingFolderTo={addingFolderTo}
+                    addingRequestTo={addingRequestTo}
+                    onRenameStart={onRenameStart}
+                    onRenameCancel={onRenameCancel}
+                    onRenameConfirm={onRenameConfirm}
+                    onMenuToggle={onMenuToggle}
+                    onMenuClose={onMenuClose}
+                    onAddFolderStart={onAddFolderStart}
+                    onAddFolderCancel={onAddFolderCancel}
+                    onAddFolderConfirm={onAddFolderConfirm}
+                    onAddRequest={onAddRequest}
+                    onDeleteFolder={onDeleteFolder}
+                    onDeleteRequest={onDeleteRequest}
+                  />
+                ))}
+              </SortableContext>
+            </div>
+          </Collapsible.Content>
+        </Collapsible.Root>
+      )}
     </div>
   )
 }
 
-// ─── Main component ───────────────────────────────────────────────────────────
-
-export function GroupSection({ source, integration, collections, groups, requests, searchQuery, dragActiveId, dragOverId }: GroupSectionProps) {
-  const [addingGroupTo, setAddingGroupTo] = useState<string | null>(null)
-  const [renamingCollection, setRenamingCollection] = useState<string | null>(null)
+export function GroupSection({ source, integration, folders, requests, searchQuery, dragActiveId, dragOverId }: GroupSectionProps) {
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null)
   const [addingCollection, setAddingCollection] = useState(false)
+  const [addingFolderTo, setAddingFolderTo] = useState<string | null>(null)
+  const [folderMenuOpen, setFolderMenuOpen] = useState<string | null>(null)
 
   const {
     toggleSourceHidden,
     hiddenSources,
-    deleteRequest,
-    createGroup,
-    addRequestToCollection,
+    addRequestToFolder,
+    createSubFolder,
+    createRootFolder,
     renameCollection,
-    createLocalRequest,
     deleteGroup,
     renameGroup,
     load,
-    toggleCollectionCollapsed,
   } = useCollectionsStore()
-  const addToast = useUIStore((s) => s.addToast)
-  const openDeleteCollection = useUIStore((s) => s.openDeleteCollection)
-  const openGitAction = useUIStore((s) => s.openGitAction)
-  const collapsedSources = useUIStore((s) => s.collapsedSources)
-  const toggleSourceCollapsed = useUIStore((s) => s.toggleSourceCollapsed)
+  const addToast = useUIStore((state) => state.addToast)
+  const openDeleteCollection = useUIStore((state) => state.openDeleteCollection)
+  const openGitAction = useUIStore((state) => state.openGitAction)
+  const collapsedSources = useUIStore((state) => state.collapsedSources)
+  const toggleSourceCollapsed = useUIStore((state) => state.toggleSourceCollapsed)
   const integrationsStore = useIntegrationsStore()
-  const { activeRequestId, setActiveRequest, clearActiveRequest } = useRequestsStore()
-  const { selectItem, clearSelectedItem, selectedItem } = useUIStore()
+  const { selectItem, selectedItem } = useUIStore()
 
-  const [renamingGroup, setRenamingGroup] = useState<string | null>(null)
-  const [groupMenuOpen, setGroupMenuOpen] = useState<string | null>(null)
+  const rootFolders = useMemo(() => {
+    const candidates = folders.filter((folder) => !folder.parentId)
+    return (integration
+      ? candidates.filter((folder) => folder.integrationId === integration.id)
+      : candidates.filter((folder) => folder.source === source && !folder.integrationId)
+    ).sort((a, b) => a.sortOrder - b.sortOrder)
+  }, [folders, integration, source])
 
-  const sourceCollections = integration
-    ? collections.filter((c) => c.integrationId === integration.id)
-    : collections.filter((c) => c.source === source && !c.integrationId)
   const isSourceHidden = hiddenSources.has(source)
   const isSourceOpen = !collapsedSources.has(source)
 
-  const totalRequests = requests.filter((r) => {
-    const group = groups.find((g) => g.id === r.groupId)
-    return group && sourceCollections.some((c) => c.id === group.collectionId)
+  const totalRequests = requests.filter((request) => {
+    const collection = getRootCollection(request.folderId, folders)
+    return collection && rootFolders.some((root) => root.id === collection.id)
   })
+
+  const handleRenameConfirm = (folder: Folder, name: string) => {
+    setRenamingFolderId(null)
+    const collection = getRootCollection(folder.id, folders)
+    if (!collection) return
+    if (!folder.parentId) {
+      renameCollection(folder.id, name)
+      if (['git', 'github', 'gitlab'].includes(collection.source)) {
+        openGitAction({ type: 'push', collectionId: collection.id, title: `Renamed collection to '${name}'` })
+      }
+      return
+    }
+    renameGroup(folder.id, name)
+    if (['git', 'github', 'gitlab'].includes(collection.source)) {
+      openGitAction({ type: 'push', collectionId: collection.id, title: `Renamed folder to '${name}'`, subtitle: collection.name })
+    }
+  }
+
+  const handleAddFolderConfirm = async (parent: Folder, name: string) => {
+    setAddingFolderTo(null)
+    const folderId = await createSubFolder(parent.id, name)
+    const collection = getRootCollection(parent.id, folders)
+    if (folderId && collection && ['git', 'github', 'gitlab'].includes(collection.source)) {
+      openGitAction({
+        type: 'push',
+        collectionId: collection.id,
+        title: `Created folder '${name}'`,
+        subtitle: collection.name,
+        onCancel: () => deleteGroup(folderId),
+      })
+    }
+  }
+
+  const handleAddRequest = (folder: Folder) => {
+    void addRequestToFolder(folder.id)
+  }
+
+  const handleDeleteFolder = (folder: Folder) => {
+    const collection = getRootCollection(folder.id, folders)
+    if (!folder.parentId) {
+      if (['git', 'github', 'gitlab'].includes(folder.source)) {
+        openGitAction({ type: 'delete-collection', collectionId: folder.id, title: `Delete collection '${folder.name}'` })
+      } else {
+        openDeleteCollection(folder.id)
+      }
+      return
+    }
+
+    void deleteGroup(folder.id).then(() => {
+      if (collection && ['git', 'github', 'gitlab'].includes(collection.source)) {
+        openGitAction({ type: 'push', collectionId: collection.id, title: `Deleted folder '${folder.name}'`, subtitle: collection.name })
+      }
+    })
+  }
+
+  const handleDeleteRequest = (folder: Folder, requestId: string) => {
+    const collection = getRootCollection(folder.id, folders)
+    void useCollectionsStore.getState().deleteRequest(requestId).then(() => {
+      if (collection && ['git', 'github', 'gitlab'].includes(collection.source)) {
+        openGitAction({ type: 'push', collectionId: collection.id, title: 'Deleted endpoint', subtitle: collection.name })
+      }
+    })
+  }
 
   return (
     <Collapsible.Root open={isSourceOpen} onOpenChange={() => toggleSourceCollapsed(source)} className="mb-1">
-      {/* Source header */}
       <div className="group/header flex items-center gap-1 rounded-sm px-2 py-0.5 text-th-text-muted hover:text-th-text-primary">
         <Collapsible.Trigger asChild>
-          <button
-            data-testid={`source-toggle-${source}`}
-            className="shrink-0 rounded-sm p-0.5 focus:outline-hidden"
-          >
+          <button data-testid={`source-toggle-${source}`} className="shrink-0 rounded-sm p-0.5 focus:outline-hidden">
             {isSourceOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
           </button>
         </Collapsible.Trigger>
 
-        <span className="shrink-0 p-0.5">
-          {integration ? SOURCE_ICONS[integration.type] : SOURCE_ICONS[source]}
-        </span>
+        <span className="shrink-0 p-0.5">{integration ? SOURCE_ICONS[integration.type] : SOURCE_ICONS[source]}</span>
 
         <button
           onClick={() => {
-            if (integration && ['git', 'github', 'gitlab'].includes(integration.type)) {
-              selectItem('git-source', integration.id)
-            } else {
-              toggleSourceCollapsed(source)
-            }
+            if (integration && ['git', 'github', 'gitlab'].includes(integration.type)) selectItem('git-source', integration.id)
+            else toggleSourceCollapsed(source)
           }}
-          className={`flex flex-1 items-center gap-1 truncate rounded-sm py-1 text-left text-sm font-semibold focus:outline-hidden ${selectedItem?.type === 'git-source' && selectedItem.id === integration?.id ? 'text-th-text-primary' : ''}`}
+          className={cn('flex flex-1 items-center gap-1 truncate rounded-sm py-1 text-left text-sm font-semibold focus:outline-hidden', selectedItem?.type === 'git-source' && selectedItem.id === integration?.id && 'text-th-text-primary')}
         >
           <span className="truncate">{integration ? integration.name : capitalize(source)}</span>
           <Badge variant="grey" className="ml-0.5">{totalRequests.length}</Badge>
@@ -432,44 +455,24 @@ export function GroupSection({ source, integration, collections, groups, request
         {integration ? (
           <div className="flex items-center gap-0.5">
             {(integration.status === 'error' || integration.status === 'disconnected') && (
-              <button
-                onClick={() => integrationsStore.connect(integration.id)}
-                className="flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs text-amber-400 hover:bg-th-surface-raised hover:text-amber-300 focus:outline-hidden"
-                title="Reconnect"
-              >
+              <button onClick={() => integrationsStore.connect(integration.id)} className="flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs text-amber-400 hover:bg-th-surface-raised hover:text-amber-300 focus:outline-hidden" title="Reconnect">
                 <AlertCircle className="h-3 w-3" />
                 <span className="hidden group-hover/header:inline">Reconnect</span>
               </button>
             )}
-            <button
-              onClick={() => { if (!isSourceOpen) toggleSourceCollapsed(source); setAddingCollection(true) }}
-              className="rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/header:opacity-100"
-              title="Add collection"
-            >
+            <button onClick={() => { if (!isSourceOpen) toggleSourceCollapsed(source); setAddingCollection(true) }} className="rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/header:opacity-100" title="Add collection">
               <Plus className="h-3.5 w-3.5" />
             </button>
-            <button
-              onClick={() => selectItem('edit-integration', integration.id)}
-              className="rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/header:opacity-100"
-              title="Edit integration"
-            >
+            <button onClick={() => selectItem('edit-integration', integration.id)} className="rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/header:opacity-100" title="Edit integration">
               <Settings className="h-3.5 w-3.5" />
             </button>
           </div>
         ) : (
           <div className="flex items-center gap-0.5">
-            <button
-              onClick={() => { if (!isSourceOpen) toggleSourceCollapsed(source); setAddingCollection(true) }}
-              className="rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/header:opacity-100"
-              title="Add collection"
-            >
+            <button onClick={() => { if (!isSourceOpen) toggleSourceCollapsed(source); setAddingCollection(true) }} className="rounded-sm p-0.5 text-th-text-faint opacity-0 hover:text-th-text-muted focus:outline-hidden group-hover/header:opacity-100" title="Add collection">
               <Plus className="h-3.5 w-3.5" />
             </button>
-            <button
-              onClick={() => toggleSourceHidden(source)}
-              className="rounded-sm p-0.5 text-th-text-faint hover:text-th-text-muted focus:outline-hidden"
-              title={isSourceHidden ? 'Show source' : 'Hide source'}
-            >
+            <button onClick={() => toggleSourceHidden(source)} className="rounded-sm p-0.5 text-th-text-faint hover:text-th-text-muted focus:outline-hidden" title={isSourceHidden ? 'Show source' : 'Hide source'}>
               {isSourceHidden ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </button>
           </div>
@@ -478,176 +481,65 @@ export function GroupSection({ source, integration, collections, groups, request
 
       <Collapsible.Content>
         <div data-testid={`source-content-${source}`} className={cn(isSourceHidden && 'opacity-40')}>
-          {sourceCollections.length === 0 && !addingCollection && (
+          {rootFolders.length === 0 && !addingCollection && (
             <div className="mx-3 my-2 rounded-sm border border-dashed border-th-border px-3 py-3 text-center">
               <p className="text-xs text-th-text-faint">No collections yet</p>
               <p className="mt-0.5 text-xs text-th-text-muted">Use + to add one</p>
             </div>
           )}
-          <SortableContext items={sourceCollections.map((c) => `col:${c.id}`)} strategy={verticalListSortingStrategy}>
-          {sourceCollections.map((collection) => {
-            const collectionGroups = groups
-              .filter((g) => g.collectionId === collection.id)
-              .sort((a, b) => a.sortOrder - b.sortOrder)
-            const isOpen = !collection.collapsed
 
-            return (
-              <div key={collection.id} className="mb-0.5">
-                {renamingCollection === collection.id ? (
-                  <InlineInput
-                    placeholder={collection.name}
-                    onConfirm={(name) => {
-                      renameCollection(collection.id, name)
-                      setRenamingCollection(null)
-                      if (['git', 'github', 'gitlab'].includes(collection.source)) {
-                        openGitAction({ type: 'push', collectionId: collection.id, title: `Renamed collection to '${name}'` })
-                      }
-                    }}
-                    onCancel={() => setRenamingCollection(null)}
-                    indent="pl-3"
-                  />
-                ) : (
-                  <CollectionRow
-                    collection={collection}
-                    open={isOpen}
-                    dndId={`col:${collection.id}`}
-                    isActive={selectedItem?.type === 'collection' && selectedItem.id === collection.id}
-                    onToggle={() => toggleCollectionCollapsed(collection.id)}
-                    onSelect={() => selectItem('collection', collection.id)}
-                    onAddRequest={() => {
-                      if (collection.collapsed) toggleCollectionCollapsed(collection.id)
-                      addRequestToCollection(collection.id)
-                    }}
-                    onAddGroup={() => {
-                      if (collection.collapsed) toggleCollectionCollapsed(collection.id)
-                      setAddingGroupTo(collection.id)
-                    }}
-                    onRename={() => setRenamingCollection(collection.id)}
-                    onDelete={() => {
-                      if (['git', 'github', 'gitlab'].includes(collection.source)) {
-                        openGitAction({ type: 'delete-collection', collectionId: collection.id, title: `Delete collection '${collection.name}'` })
-                      } else {
-                        openDeleteCollection(collection.id)
-                      }
-                    }}
-                    onAi={() => selectItem('ai-collection', collection.id)}
-                  />
-                )}
-
-                {(isOpen || !!searchQuery) && (
-                  <div data-testid={`collection-content-${collection.id}`} className="pl-3">
-                    <SortableContext items={collectionGroups.map((g) => `grp:${g.id}`)} strategy={verticalListSortingStrategy}>
-                      {collectionGroups.map((group) => (
-                        <SortableGroupRow
-                          key={group.id}
-                          group={group}
-                          requests={requests}
-                          searchQuery={searchQuery}
-                          renamingGroup={renamingGroup}
-                          groupMenuOpen={groupMenuOpen}
-                          selectedItem={selectedItem}
-                          activeRequestId={activeRequestId}
-                          dragActiveId={dragActiveId}
-                          dragOverId={dragOverId}
-                          onRenameConfirm={(name) => {
-                            renameGroup(group.id, name)
-                            setRenamingGroup(null)
-                            const col = collections.find((c) => c.id === group.collectionId)
-                            if (col && ['git', 'github', 'gitlab'].includes(col.source)) {
-                              openGitAction({ type: 'push', collectionId: col.id, title: `Renamed group to '${name}'`, subtitle: col.name })
-                            }
-                          }}
-                          onRenameCancel={() => setRenamingGroup(null)}
-                          onSelect={() => selectItem('group', group.id)}
-                          onAddRequest={() => { createLocalRequest(group.id) }}
-                          onMenuToggle={() => setGroupMenuOpen(groupMenuOpen === group.id ? null : group.id)}
-                          onMenuClose={() => setGroupMenuOpen(null)}
-                          onRenameStart={() => setRenamingGroup(group.id)}
-                          onDelete={() => {
-                            const col = collections.find((c) => c.id === group.collectionId)
-                            deleteGroup(group.id).then(() => {
-                              if (col && ['git', 'github', 'gitlab'].includes(col.source)) {
-                                openGitAction({ type: 'push', collectionId: col.id, title: `Deleted group '${group.name}'`, subtitle: col.name })
-                              }
-                            })
-                          }}
-                          onAiGroup={() => selectItem('ai-group', group.id)}
-                          onDeleteRequest={(reqId) => {
-                            const col = collections.find((c) => c.id === group.collectionId)
-                            deleteRequest(reqId).then(() => {
-                              if (activeRequestId === reqId) clearActiveRequest()
-                              if (col && ['git', 'github', 'gitlab'].includes(col.source)) {
-                                openGitAction({ type: 'push', collectionId: col.id, title: 'Deleted endpoint', subtitle: col.name })
-                              }
-                            })
-                          }}
-                          onClickRequest={(req) => { clearSelectedItem(); setActiveRequest(req) }}
-                        />
-                      ))}
-                    </SortableContext>
-
-                    {!searchQuery && addingGroupTo === collection.id && (
-                      <InlineInput
-                        placeholder="Group name…"
-                        onConfirm={(name) => {
-                          setAddingGroupTo(null)
-                          if (['git', 'github', 'gitlab'].includes(collection.source)) {
-                            createGroup(collection.id, name).then((groupId) => {
-                              if (!groupId) return
-                              openGitAction({
-                                type: 'push',
-                                collectionId: collection.id,
-                                title: `Created group '${name}'`,
-                                subtitle: collection.name,
-                                onCancel: () => deleteGroup(groupId),
-                              })
-                            })
-                          } else {
-                            createGroup(collection.id, name)
-                          }
-                        }}
-                        onCancel={() => setAddingGroupTo(null)}
-                        indent="pl-2"
-                      />
-                    )}
-
-                    {!searchQuery && collectionGroups.length === 0 && addingGroupTo !== collection.id && (
-                      <div className="mx-2 my-1.5 rounded-sm border border-dashed border-th-border px-2 py-2 text-center">
-                        <p className="text-xs text-th-text-faint">No groups defined</p>
-                        <p className="mt-0.5 text-xs text-th-text-muted">Use + to add one</p>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            )
-          })}
+          <SortableContext items={rootFolders.map((folder) => `fld:${folder.id}`)} strategy={verticalListSortingStrategy}>
+            {rootFolders.map((folder) => (
+              <FolderTreeRow
+                key={folder.id}
+                folder={folder}
+                depth={0}
+                allFolders={folders}
+                requests={requests}
+                searchQuery={searchQuery}
+                dragActiveId={dragActiveId}
+                dragOverId={dragOverId}
+                renamingFolderId={renamingFolderId}
+                folderMenuOpen={folderMenuOpen}
+                addingFolderTo={addingFolderTo}
+                addingRequestTo={null}
+                onRenameStart={setRenamingFolderId}
+                onRenameCancel={() => setRenamingFolderId(null)}
+                onRenameConfirm={handleRenameConfirm}
+                onMenuToggle={(folderId) => setFolderMenuOpen(folderMenuOpen === folderId ? null : folderId)}
+                onMenuClose={() => setFolderMenuOpen(null)}
+                onAddFolderStart={setAddingFolderTo}
+                onAddFolderCancel={() => setAddingFolderTo(null)}
+                onAddFolderConfirm={handleAddFolderConfirm}
+                onAddRequest={handleAddRequest}
+                onDeleteFolder={handleDeleteFolder}
+                onDeleteRequest={handleDeleteRequest}
+              />
+            ))}
           </SortableContext>
 
           {addingCollection && (
             <InlineInput
               placeholder="Collection name…"
+              paddingLeft={16}
               onConfirm={async (name) => {
                 setAddingCollection(false)
-                const payload: { name: string; source: string; integrationId?: string } = { name, source }
-                if (integration) payload.integrationId = integration.id
-                const { error, data } = await window.api.collections.create(payload)
-                if (error) addToast('Failed to create collection', 'error')
-                else {
-                  await load()
-                  if (['git', 'github', 'gitlab'].includes(source) && data?.id) {
-                    const colId = data.id
-                    openGitAction({
-                      type: 'push',
-                      collectionId: colId,
-                      title: `Created collection '${name}'`,
-                      onCancel: () => window.api.collections.delete({ id: colId }).then(() => load()),
-                    })
-                  }
+                const collectionId = await createRootFolder(name, source, integration?.id)
+                if (!collectionId) {
+                  addToast('Failed to create collection', 'error')
+                  return
+                }
+                await load()
+                if (['git', 'github', 'gitlab'].includes(source)) {
+                  openGitAction({
+                    type: 'push',
+                    collectionId,
+                    title: `Created collection '${name}'`,
+                    onCancel: () => window.api.folders.delete({ id: collectionId }).then(() => load()),
+                  })
                 }
               }}
               onCancel={() => setAddingCollection(false)}
-              indent="pl-2"
             />
           )}
         </div>

--- a/src/renderer/src/lib/__tests__/aiContext.test.ts
+++ b/src/renderer/src/lib/__tests__/aiContext.test.ts
@@ -3,7 +3,7 @@ import { buildSystemPrompt } from '../aiContext'
 import type { AiContext } from '../aiContext'
 
 const makeRequest = (overrides = {}) => ({
-  id: 'r1', groupId: 'g1', name: 'Get Users', method: 'GET' as const,
+  id: 'r1', folderId: 'f1', name: 'Get Users', method: 'GET' as const,
   url: '/api/users', params: [], headers: [], bodyType: 'none' as const,
   bodyContent: '', authType: 'none' as const, authConfig: {},
   sslVerification: 'inherit' as const, protocol: 'http' as const,
@@ -24,8 +24,7 @@ describe('buildSystemPrompt – collection context', () => {
   })
 
   it('includes REST best practices', () => {
-    const prompt = buildSystemPrompt(ctx)
-    expect(prompt).toMatch(/REST|HTTP/i)
+    expect(buildSystemPrompt(ctx)).toMatch(/REST|HTTP/i)
   })
 
   it('reports no existing endpoints when list is empty', () => {
@@ -33,30 +32,26 @@ describe('buildSystemPrompt – collection context', () => {
   })
 
   it('lists existing endpoints when present', () => {
-    const ctxWithRequests: AiContext = {
-      ...ctx,
-      existingRequests: [makeRequest({ name: 'List Posts', url: '/api/posts' })],
-    }
-    const prompt = buildSystemPrompt(ctxWithRequests)
+    const prompt = buildSystemPrompt({ ...ctx, existingRequests: [makeRequest({ name: 'List Posts', url: '/api/posts' })] })
     expect(prompt).toContain('List Posts')
     expect(prompt).toContain('/api/posts')
   })
 
   it('includes description when provided', () => {
-    const ctxWithDesc: AiContext = { ...ctx, description: 'Blog management API' }
-    expect(buildSystemPrompt(ctxWithDesc)).toContain('Blog management API')
+    expect(buildSystemPrompt({ ...ctx, description: 'Blog management API' })).toContain('Blog management API')
   })
 })
 
 describe('buildSystemPrompt – group context', () => {
   const ctx: AiContext = {
     type: 'group',
+    folderId: 'f1',
     name: 'Auth Endpoints',
     collectionName: 'My API',
     existingRequests: [],
   }
 
-  it('mentions the group name', () => {
+  it('mentions the folder name', () => {
     expect(buildSystemPrompt(ctx)).toContain('Auth Endpoints')
   })
 
@@ -72,6 +67,7 @@ describe('buildSystemPrompt – group context', () => {
 describe('buildSystemPrompt – request context', () => {
   const ctx: AiContext = {
     type: 'request',
+    folderId: 'f1',
     name: 'Get User by ID',
     existingRequests: [],
     currentRequest: makeRequest({
@@ -94,24 +90,20 @@ describe('buildSystemPrompt – request context', () => {
   })
 
   it('produces a review-oriented prompt', () => {
-    const prompt = buildSystemPrompt(ctx)
-    expect(prompt).toMatch(/review|best practice|improvement/i)
+    expect(buildSystemPrompt(ctx)).toMatch(/review|best practice|improvement/i)
   })
 })
 
 describe('buildSystemPrompt – protocol best practices', () => {
   it('includes GraphQL guidance', () => {
-    const ctx: AiContext = { type: 'collection', name: 'GQL', existingRequests: [] }
-    expect(buildSystemPrompt(ctx)).toMatch(/graphql/i)
+    expect(buildSystemPrompt({ type: 'collection', name: 'GQL', existingRequests: [] })).toMatch(/graphql/i)
   })
 
   it('includes WebSocket guidance', () => {
-    const ctx: AiContext = { type: 'collection', name: 'WS', existingRequests: [] }
-    expect(buildSystemPrompt(ctx)).toMatch(/websocket/i)
+    expect(buildSystemPrompt({ type: 'collection', name: 'WS', existingRequests: [] })).toMatch(/websocket/i)
   })
 
   it('includes endpoint block format spec', () => {
-    const ctx: AiContext = { type: 'collection', name: 'API', existingRequests: [] }
-    expect(buildSystemPrompt(ctx)).toContain('```endpoints')
+    expect(buildSystemPrompt({ type: 'collection', name: 'API', existingRequests: [] })).toContain('```endpoints')
   })
 })

--- a/src/renderer/src/lib/__tests__/normalizers.test.ts
+++ b/src/renderer/src/lib/__tests__/normalizers.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { parseJsonField, normalizeRequest, normalizeGroup, kvpToRecord, serializeRequest } from '../normalizers'
+import { parseJsonField, normalizeRequest, normalizeGroup, normalizeFolder, kvpToRecord, serializeRequest } from '../normalizers'
 
-// ---------------------------------------------------------------------------
-// parseJsonField
-// ---------------------------------------------------------------------------
 describe('parseJsonField', () => {
   it('parses valid JSON string', () => {
     expect(parseJsonField('{"a":1}', {})).toEqual({ a: 1 })
@@ -31,64 +28,55 @@ describe('parseJsonField', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// normalizeRequest
-// ---------------------------------------------------------------------------
 describe('normalizeRequest', () => {
   const base = {
     id: 'req-1',
-    group_id: 'grp-1',
+    folder_id: 'fld-1',
     name: 'Get Users',
     method: 'GET',
     url: '/api/users',
   }
 
   it('maps camelCase and snake_case fields', () => {
-    const r = normalizeRequest(base)
-    expect(r.id).toBe('req-1')
-    expect(r.groupId).toBe('grp-1')
-    expect(r.name).toBe('Get Users')
+    const request = normalizeRequest(base)
+    expect(request.id).toBe('req-1')
+    expect(request.folderId).toBe('fld-1')
+    expect(request.name).toBe('Get Users')
   })
 
   it('defaults method to GET', () => {
-    const r = normalizeRequest({ ...base, method: undefined })
-    expect(r.method).toBe('GET')
+    expect(normalizeRequest({ ...base, method: undefined }).method).toBe('GET')
   })
 
   it('defaults url to empty string', () => {
-    const r = normalizeRequest({ ...base, url: undefined })
-    expect(r.url).toBe('')
+    expect(normalizeRequest({ ...base, url: undefined }).url).toBe('')
   })
 
   it('defaults bodyType to none', () => {
-    const r = normalizeRequest(base)
-    expect(r.bodyType).toBe('none')
+    expect(normalizeRequest(base).bodyType).toBe('none')
   })
 
   it('defaults protocol to http', () => {
-    const r = normalizeRequest(base)
-    expect(r.protocol).toBe('http')
+    expect(normalizeRequest(base).protocol).toBe('http')
   })
 
   it('defaults authType to none', () => {
-    const r = normalizeRequest(base)
-    expect(r.authType).toBe('none')
+    expect(normalizeRequest(base).authType).toBe('none')
   })
 
   it('parses params JSON string', () => {
-    const r = normalizeRequest({ ...base, params: '[{"id":"1","key":"q","value":"test","enabled":true}]' })
-    expect(r.params).toHaveLength(1)
-    expect(r.params[0].key).toBe('q')
+    const request = normalizeRequest({ ...base, params: '[{"id":"1","key":"q","value":"test","enabled":true}]' })
+    expect(request.params).toHaveLength(1)
+    expect(request.params[0].key).toBe('q')
   })
 
   it('defaults params to empty array on bad JSON', () => {
-    const r = normalizeRequest({ ...base, params: 'bad' })
-    expect(r.params).toEqual([])
+    expect(normalizeRequest({ ...base, params: 'bad' }).params).toEqual([])
   })
 
-  it('prefers camelCase over snake_case for groupId', () => {
-    const r = normalizeRequest({ ...base, groupId: 'camel', group_id: 'snake' })
-    expect(r.groupId).toBe('camel')
+  it('prefers camelCase over snake_case for folderId', () => {
+    const request = normalizeRequest({ ...base, folderId: 'camel', folder_id: 'snake' })
+    expect(request.folderId).toBe('camel')
   })
 
   it('maps isDirty correctly', () => {
@@ -101,26 +89,23 @@ describe('normalizeRequest', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// normalizeGroup
-// ---------------------------------------------------------------------------
-describe('normalizeGroup', () => {
+describe('normalizeFolder', () => {
   const base = {
-    id: 'grp-1',
-    collection_id: 'col-1',
+    id: 'fld-1',
+    parent_id: 'col-1',
     name: 'Auth',
   }
 
-  it('maps collection_id to collectionId', () => {
-    expect(normalizeGroup(base).collectionId).toBe('col-1')
+  it('maps parent_id to parentId', () => {
+    expect(normalizeFolder(base).parentId).toBe('col-1')
   })
 
   it('defaults collapsed to false', () => {
-    expect(normalizeGroup(base).collapsed).toBe(false)
+    expect(normalizeFolder(base).collapsed).toBe(false)
   })
 
   it('defaults hidden to false', () => {
-    expect(normalizeGroup(base).hidden).toBe(false)
+    expect(normalizeFolder(base).hidden).toBe(false)
   })
 
   it('defaults authType to none', () => {
@@ -132,14 +117,11 @@ describe('normalizeGroup', () => {
   })
 
   it('parses authConfig JSON', () => {
-    const r = normalizeGroup({ ...base, auth_config: '{"token":"abc"}' })
-    expect(r.authConfig).toEqual({ token: 'abc' })
+    const folder = normalizeGroup({ ...base, auth_config: '{"token":"abc"}' })
+    expect(folder.authConfig).toEqual({ token: 'abc' })
   })
 })
 
-// ---------------------------------------------------------------------------
-// kvpToRecord
-// ---------------------------------------------------------------------------
 describe('kvpToRecord', () => {
   it('converts enabled pairs to a record', () => {
     const result = kvpToRecord([
@@ -179,12 +161,9 @@ describe('kvpToRecord', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// serializeRequest
-// ---------------------------------------------------------------------------
 describe('serializeRequest', () => {
   const req = {
-    id: 'r1', groupId: 'g1', name: 'Test', method: 'POST' as const,
+    id: 'r1', folderId: 'f1', name: 'Test', method: 'POST' as const,
     url: '/api', params: [{ id: '1', key: 'q', value: '1', enabled: true }],
     headers: [{ id: '2', key: 'Accept', value: '*/*', enabled: true }],
     bodyType: 'json' as const, bodyContent: '{}',
@@ -194,26 +173,26 @@ describe('serializeRequest', () => {
   }
 
   it('stringifies params', () => {
-    const s = serializeRequest(req)
-    expect(typeof s.params).toBe('string')
-    expect(JSON.parse(s.params as string)).toEqual(req.params)
+    const serialized = serializeRequest(req)
+    expect(typeof serialized.params).toBe('string')
+    expect(JSON.parse(serialized.params as string)).toEqual(req.params)
   })
 
   it('stringifies headers', () => {
-    const s = serializeRequest(req)
-    expect(typeof s.headers).toBe('string')
+    const serialized = serializeRequest(req)
+    expect(typeof serialized.headers).toBe('string')
   })
 
   it('stringifies authConfig', () => {
-    const s = serializeRequest(req)
-    expect(JSON.parse(s.authConfig as string)).toEqual({ token: 'abc' })
+    const serialized = serializeRequest(req)
+    expect(JSON.parse(serialized.authConfig as string)).toEqual({ token: 'abc' })
   })
 
   it('preserves non-serialized fields', () => {
-    const s = serializeRequest(req)
-    expect(s.id).toBe('r1')
-    expect(s.url).toBe('/api')
-    expect(s.method).toBe('POST')
+    const serialized = serializeRequest(req)
+    expect(serialized.id).toBe('r1')
+    expect(serialized.url).toBe('/api')
+    expect(serialized.method).toBe('POST')
   })
 
   it('does not mutate the original request', () => {

--- a/src/renderer/src/lib/__tests__/normalizers.test.ts
+++ b/src/renderer/src/lib/__tests__/normalizers.test.ts
@@ -44,6 +44,11 @@ describe('normalizeRequest', () => {
     expect(request.name).toBe('Get Users')
   })
 
+  it('maps folder_id to folderId', () => {
+    const request = normalizeRequest({ ...base, folder_id: 'folder-from-snake' })
+    expect(request.folderId).toBe('folder-from-snake')
+  })
+
   it('defaults method to GET', () => {
     expect(normalizeRequest({ ...base, method: undefined }).method).toBe('GET')
   })
@@ -96,8 +101,69 @@ describe('normalizeFolder', () => {
     name: 'Auth',
   }
 
+  it('normalizes all folder fields from snake_case input', () => {
+    const folder = normalizeFolder({
+      id: 'fld-1',
+      parent_id: 'col-1',
+      name: 'Auth',
+      description: 'Folder description',
+      source: 'local',
+      hidden: 0,
+      collapsed: 0,
+      sort_order: 7,
+      created_at: 123,
+      updated_at: 456,
+      auth_type: 'bearer',
+      auth_config: '{"token":"abc"}',
+      ssl_verification: 'disabled',
+    })
+
+    expect(folder).toEqual({
+      id: 'fld-1',
+      parentId: 'col-1',
+      name: 'Auth',
+      description: 'Folder description',
+      source: 'local',
+      sourceMeta: undefined,
+      integrationId: undefined,
+      authType: 'bearer',
+      authConfig: { token: 'abc' },
+      sslVerification: 'disabled',
+      hidden: false,
+      collapsed: false,
+      sortOrder: 7,
+      createdAt: 123,
+      updatedAt: 456,
+    })
+  })
+
   it('maps parent_id to parentId', () => {
     expect(normalizeFolder(base).parentId).toBe('col-1')
+  })
+
+  it('handles missing optional fields with defaults', () => {
+    expect(normalizeFolder({ id: 'fld-2', name: 'Empty' })).toEqual({
+      id: 'fld-2',
+      parentId: undefined,
+      name: 'Empty',
+      description: '',
+      source: 'local',
+      sourceMeta: undefined,
+      integrationId: undefined,
+      authType: 'none',
+      authConfig: {},
+      sslVerification: 'inherit',
+      hidden: false,
+      collapsed: false,
+      sortOrder: 0,
+      createdAt: 0,
+      updatedAt: 0,
+    })
+  })
+
+  it('handles camelCase parentId as well as snake_case parent_id', () => {
+    const folder = normalizeFolder({ ...base, parentId: 'camel-parent', parent_id: 'snake-parent' })
+    expect(folder.parentId).toBe('camel-parent')
   })
 
   it('defaults collapsed to false', () => {

--- a/src/renderer/src/lib/aiContext.ts
+++ b/src/renderer/src/lib/aiContext.ts
@@ -3,10 +3,10 @@ import type { Request } from '@/types'
 export interface AiContext {
   type: 'collection' | 'group' | 'request'
   collectionId?: string
-  groupId?: string
+  folderId?: string
   name: string
   collectionName?: string
-  groupName?: string
+  folderName?: string
   existingRequests: Request[]
   currentRequest?: Request
   description?: string
@@ -22,13 +22,12 @@ ${ctx.existingRequests.length > 0 ? `\nExisting endpoints (${ctx.existingRequest
 When creating endpoints, build on existing ones if present (same base URL patterns, auth headers, etc.).`
     }
     if (ctx.type === 'group') {
-      return `Working in group: "${ctx.name}"${ctx.collectionName ? ` (collection: "${ctx.collectionName}")` : ''}
+      return `Working in folder: "${ctx.name}"${ctx.collectionName ? ` (collection: "${ctx.collectionName}")` : ''}
 ${ctx.description ? `Description: ${ctx.description}` : ''}
-${ctx.existingRequests.length > 0 ? `\nExisting endpoints in this group (${ctx.existingRequests.length}):\n${ctx.existingRequests.map(r => `- ${r.name}: ${r.protocol?.toUpperCase() ?? r.method} ${r.url}`).join('\n')}` : 'No existing endpoints yet.'}
+${ctx.existingRequests.length > 0 ? `\nExisting endpoints in this folder (${ctx.existingRequests.length}):\n${ctx.existingRequests.map(r => `- ${r.name}: ${r.protocol?.toUpperCase() ?? r.method} ${r.url}`).join('\n')}` : 'No existing endpoints yet.'}
 
 When creating endpoints, build on existing ones if present (same base URL patterns, auth headers, etc.).`
     }
-    // request type — review mode
     if (!ctx.currentRequest) return ''
     const req = ctx.currentRequest
     const headers = (req.headers ?? []).map((h) => `  ${h.key}: ${h.value}`).join('\n')
@@ -42,7 +41,7 @@ ${headers ? `- Headers:\n${headers}` : ''}
 ${params ? `- Query params:\n${params}` : ''}
 ${req.bodyType && req.bodyType !== 'none' ? `- Body type: ${req.bodyType}` : ''}
 ${req.description ? `- Description: ${req.description}` : ''}
-${ctx.groupName ? `\nGroup: "${ctx.groupName}"` : ''}${ctx.collectionName ? `  Collection: "${ctx.collectionName}"` : ''}
+${ctx.folderName ? `\nFolder: "${ctx.folderName}"` : ''}${ctx.collectionName ? `  Collection: "${ctx.collectionName}"` : ''}
 ${ctx.existingRequests.length > 1 ? `\nSibling endpoints (${ctx.existingRequests.length - 1}):\n${ctx.existingRequests.filter(r => r.id !== req.id).map(r => `- ${r.name}: ${r.protocol?.toUpperCase() ?? r.method} ${r.url}`).join('\n')}` : ''}
 
 You can review this endpoint for best practices, suggest improvements, or help create additional related endpoints.`

--- a/src/renderer/src/lib/normalizers.ts
+++ b/src/renderer/src/lib/normalizers.ts
@@ -1,8 +1,4 @@
-import type { Group, KeyValuePair, Request } from '@/types'
-
-// ---------------------------------------------------------------------------
-// JSON field parsing
-// ---------------------------------------------------------------------------
+import type { Folder, KeyValuePair, Request } from '@/types'
 
 export function parseJsonField<T>(value: unknown, fallback: T): T {
   if (typeof value === 'string') {
@@ -16,14 +12,10 @@ export function parseJsonField<T>(value: unknown, fallback: T): T {
   return fallback
 }
 
-// ---------------------------------------------------------------------------
-// Request / Group normalization (raw DB row → typed object)
-// ---------------------------------------------------------------------------
-
 export function normalizeRequest(raw: Record<string, unknown>): Request {
   return {
     id: raw.id as string,
-    groupId: (raw.groupId ?? raw.group_id) as string,
+    folderId: (raw.folderId ?? raw.folder_id ?? raw.groupId ?? raw.group_id) as string,
     name: raw.name as string,
     method: (raw.method ?? 'GET') as Request['method'],
     url: (raw.url ?? '') as string,
@@ -44,24 +36,28 @@ export function normalizeRequest(raw: Record<string, unknown>): Request {
   }
 }
 
-export function normalizeGroup(raw: Record<string, unknown>): Group {
+export function normalizeFolder(raw: Record<string, unknown>): Folder {
   return {
     id: raw.id as string,
-    collectionId: (raw.collectionId ?? raw.collection_id) as string,
+    parentId: ((raw.parentId ?? raw.parent_id ?? undefined) as string | undefined) || undefined,
     name: raw.name as string,
-    description: raw.description as string | undefined,
-    collapsed: Boolean(raw.collapsed ?? false),
-    hidden: Boolean(raw.hidden ?? false),
-    sortOrder: (raw.sortOrder ?? raw.sort_order ?? 0) as number,
-    authType: (raw.authType ?? raw.auth_type ?? 'none') as Group['authType'],
+    description: (raw.description as string | undefined) ?? '',
+    source: (raw.source ?? 'local') as Folder['source'],
+    sourceMeta: parseJsonField<Record<string, string> | undefined>(raw.sourceMeta ?? raw.source_meta, undefined),
+    integrationId: (raw.integrationId ?? raw.integration_id ?? undefined) as string | undefined,
+    authType: (raw.authType ?? raw.auth_type ?? 'none') as Folder['authType'],
     authConfig: parseJsonField<Record<string, string>>(raw.authConfig ?? raw.auth_config, {}),
-    sslVerification: (raw.sslVerification ?? raw.ssl_verification ?? 'inherit') as Group['sslVerification'],
+    sslVerification: (raw.sslVerification ?? raw.ssl_verification ?? 'inherit') as Folder['sslVerification'],
+    hidden: Boolean(raw.hidden ?? false),
+    collapsed: Boolean(raw.collapsed ?? false),
+    sortOrder: (raw.sortOrder ?? raw.sort_order ?? 0) as number,
+    createdAt: (raw.createdAt ?? raw.created_at ?? 0) as number,
+    updatedAt: (raw.updatedAt ?? raw.updated_at ?? 0) as number,
   }
 }
 
-// ---------------------------------------------------------------------------
-// Key-value pair helpers
-// ---------------------------------------------------------------------------
+export const normalizeGroup = normalizeFolder
+export const normalizeCollection = normalizeFolder
 
 export function kvpToRecord(pairs: KeyValuePair[]): Record<string, string> {
   return pairs

--- a/src/renderer/src/store/__tests__/requests.test.ts
+++ b/src/renderer/src/store/__tests__/requests.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Mock window.api before importing the store
 const mockHttpExecute = vi.fn()
 const mockHttpCancel = vi.fn()
 const mockDraftsGet = vi.fn()
@@ -16,10 +15,9 @@ vi.stubGlobal('window', {
   },
 })
 
-// Mock the collections store
 vi.mock('../collections', () => ({
   useCollectionsStore: {
-    getState: () => ({ syncRequest: vi.fn(), groups: [], collections: [], markDirty: vi.fn() }),
+    getState: () => ({ syncRequest: vi.fn(), folders: [], collections: [], markDirty: vi.fn(), requests: [] }),
   },
 }))
 
@@ -42,7 +40,7 @@ function makeRequest(overrides: Partial<Request> = {}): Request {
     protocolConfig: {},
     sslVerification: 'inherit',
     isDirty: false,
-    groupId: 'group-1',
+    folderId: 'folder-1',
     sortOrder: 0,
     ...overrides,
   }
@@ -58,7 +56,6 @@ beforeEach(() => {
   mockDraftsUpsert.mockResolvedValue({})
   mockDraftsDelete.mockResolvedValue({})
   mockRequestsUpdate.mockResolvedValue({ error: null })
-  // Reset store state between tests
   useRequestsStore.setState({
     activeRequestId: null,
     editingRequest: null,
@@ -71,7 +68,7 @@ beforeEach(() => {
 describe('useRequestsStore — sendRequest', () => {
   it('sets isLoading=true while the request is in flight', async () => {
     let resolveExecute!: (v: unknown) => void
-    mockHttpExecute.mockReturnValue(new Promise((r) => { resolveExecute = r }))
+    mockHttpExecute.mockReturnValue(new Promise((resolve) => { resolveExecute = resolve }))
 
     useRequestsStore.setState({ editingRequest: makeRequest() })
 
@@ -107,15 +104,12 @@ describe('useRequestsStore — sendRequest', () => {
 
   it('blocks a second sendRequest call while one is already in flight', async () => {
     let resolveFirst!: (v: unknown) => void
-    mockHttpExecute.mockReturnValueOnce(new Promise((r) => { resolveFirst = r }))
+    mockHttpExecute.mockReturnValueOnce(new Promise((resolve) => { resolveFirst = resolve }))
 
     useRequestsStore.setState({ editingRequest: makeRequest() })
 
     const firstSend = useRequestsStore.getState().sendRequest()
-    // Attempt second send while first is in flight
     await useRequestsStore.getState().sendRequest()
-
-    // Only one http.execute call should have been made
     expect(mockHttpExecute).toHaveBeenCalledTimes(1)
 
     resolveFirst({ data: makeResponse() })
@@ -131,9 +125,8 @@ describe('useRequestsStore — sendRequest', () => {
     mockHttpExecute.mockResolvedValue({ data: makeResponse() })
     useRequestsStore.setState({ editingRequest: makeRequest(), response: makeResponse() })
 
-    // Start but don't await — check that response was cleared immediately
     let resolveExecute!: (v: unknown) => void
-    mockHttpExecute.mockReturnValue(new Promise((r) => { resolveExecute = r }))
+    mockHttpExecute.mockReturnValue(new Promise((resolve) => { resolveExecute = resolve }))
 
     const sendPromise = useRequestsStore.getState().sendRequest()
     expect(useRequestsStore.getState().response).toBeNull()

--- a/src/renderer/src/store/collections.ts
+++ b/src/renderer/src/store/collections.ts
@@ -1,19 +1,24 @@
 import { create } from 'zustand'
-import type { AuthType, Collection, CollectionSource, Group, Request, SslVerification } from '../types'
-import { parseJsonField, normalizeRequest, normalizeGroup } from '@/lib/normalizers'
+import type { AuthType, Collection, CollectionSource, Folder, Group, Request, SslVerification } from '../types'
+import { normalizeFolder, normalizeRequest } from '@/lib/normalizers'
 
 interface CollectionsState {
+  folders: Folder[]
   collections: Collection[]
   groups: Group[]
   requests: Request[]
   searchQuery: string
   hiddenSources: Set<CollectionSource>
   load: () => Promise<void>
+  toggleFolderCollapsed: (folderId: string) => Promise<void>
   toggleGroupCollapsed: (groupId: string) => Promise<void>
   toggleCollectionCollapsed: (collectionId: string) => Promise<void>
   toggleSourceHidden: (source: CollectionSource) => void
   setSearchQuery: (q: string) => void
-  createGroup: (collectionId: string, name: string) => Promise<string | null>
+  createSubFolder: (parentId: string, name: string) => Promise<string | null>
+  createRootFolder: (name: string, source?: CollectionSource, integrationId?: string) => Promise<string | null>
+  createGroup: (parentId: string, name: string) => Promise<string | null>
+  addRequestToFolder: (folderId: string) => Promise<void>
   addRequestToCollection: (collectionId: string) => Promise<void>
   deleteCollection: (id: string, commitMessage?: string) => Promise<void>
   renameCollection: (id: string, name: string) => Promise<void>
@@ -22,16 +27,42 @@ interface CollectionsState {
   syncRequest: (request: Request) => void
   clearDirtyForCollection: (collectionId: string) => void
   updateCollection: (id: string, updates: { name?: string; description?: string; authType?: AuthType; authConfig?: Record<string, string>; sslVerification?: SslVerification; collapsed?: boolean }) => Promise<void>
-  updateGroup: (id: string, updates: { name?: string; description?: string; authType?: AuthType; authConfig?: Record<string, string>; sslVerification?: SslVerification }) => Promise<void>
+  updateGroup: (id: string, updates: { name?: string; description?: string; authType?: AuthType; authConfig?: Record<string, string>; sslVerification?: SslVerification; collapsed?: boolean }) => Promise<void>
   deleteGroup: (id: string) => Promise<void>
   renameGroup: (id: string, name: string) => Promise<void>
-  createLocalRequest: (groupId: string) => Promise<void>
-  moveRequestToGroup: (requestId: string, newGroupId: string, insertBeforeId: string | null) => Promise<void>
-  moveGroupToCollection: (groupId: string, newCollectionId: string, insertBeforeId: string | null) => Promise<void>
+  createLocalRequest: (folderId: string) => Promise<void>
+  moveRequestToFolder: (requestId: string, newFolderId: string, insertBeforeId: string | null) => Promise<void>
+  moveRequestToGroup: (requestId: string, newFolderId: string, insertBeforeId: string | null) => Promise<void>
+  moveFolder: (folderId: string, newParentId: string | null, insertBeforeId: string | null) => Promise<void>
+  moveGroupToCollection: (folderId: string, newParentId: string, insertBeforeId: string | null) => Promise<void>
   moveCollectionToSource: (collectionId: string, newSource: CollectionSource) => Promise<void>
 }
 
+function deriveFoldersState(folders: Folder[]) {
+  return {
+    folders,
+    collections: folders.filter((folder) => !folder.parentId),
+    groups: folders.filter((folder) => !!folder.parentId),
+  }
+}
+
+function getDescendantFolderIds(folders: Folder[], rootId: string): Set<string> {
+  const ids = new Set<string>([rootId])
+  let added = true
+  while (added) {
+    added = false
+    for (const folder of folders) {
+      if (folder.parentId && ids.has(folder.parentId) && !ids.has(folder.id)) {
+        ids.add(folder.id)
+        added = true
+      }
+    }
+  }
+  return ids
+}
+
 export const useCollectionsStore = create<CollectionsState>((set, get) => ({
+  folders: [],
   collections: [],
   groups: [],
   requests: [],
@@ -39,295 +70,305 @@ export const useCollectionsStore = create<CollectionsState>((set, get) => ({
   hiddenSources: new Set<CollectionSource>(),
 
   load: async () => {
-    const api = window.api
-    const { data, error: collectionsError } = await api.collections.list()
-    if (collectionsError || !data) {
-      console.error('Failed to load collections:', collectionsError)
+    const { data, error } = await window.api.folders.list()
+    if (error || !data) {
+      console.error('Failed to load folders:', error)
       return
     }
 
-    // IPC returns { collections: [...], groups: [...] } as two flat arrays
-    const rawCollections: Record<string, unknown>[] = data.collections ?? []
-    const rawGroups: Record<string, unknown>[] = data.groups ?? []
+    const folders = (data as Record<string, unknown>[]).map(normalizeFolder)
+    const requestResults = await Promise.all(
+      folders.map(async (folder) => {
+        const result = await window.api.requests.list({ folderId: folder.id })
+        if (result.error) {
+          console.error(`Failed to load requests for folder ${folder.id}:`, result.error)
+          return [] as Request[]
+        }
+        return ((result.data ?? []) as Record<string, unknown>[]).map(normalizeRequest)
+      })
+    )
 
-    const collections: Collection[] = rawCollections.map((c) => ({
-      id: c.id as string,
-      name: c.name as string,
-      description: (c.description ?? '') as string,
-      source: (c.source ?? 'local') as CollectionSource,
-      sourceMeta: parseJsonField<Record<string, string> | undefined>(c.source_meta, undefined),
-      integrationId: (c.integration_id ?? undefined) as string | undefined,
-      authType: (c.auth_type ?? 'none') as AuthType,
-      authConfig: parseJsonField<Record<string, string>>(c.auth_config, {}),
-      sslVerification: (c.ssl_verification ?? 'inherit') as SslVerification,
-      collapsed: Boolean(c.collapsed),
-      createdAt: (c.created_at ?? 0) as number,
-      updatedAt: (c.updated_at ?? 0) as number,
-    }))
+    set({
+      ...deriveFoldersState(folders),
+      requests: requestResults.flat(),
+    })
+  },
 
-    const allGroups: Group[] = rawGroups.map(normalizeGroup)
-    const allRequests: Request[] = []
-
-    for (const group of allGroups) {
-      const { data: reqData, error: reqError } = await api.requests.list({ groupId: group.id })
-      if (reqError) {
-        console.error(`Failed to load requests for group ${group.id}:`, reqError)
-        continue
-      }
-      const reqs: Request[] = (reqData ?? []).map((r: Record<string, unknown>) => normalizeRequest(r))
-      allRequests.push(...reqs)
+  toggleFolderCollapsed: async (folderId: string) => {
+    const folder = get().folders.find((item) => item.id === folderId)
+    if (!folder) return
+    const collapsed = !folder.collapsed
+    const { error } = await window.api.folders.update({ id: folderId, collapsed })
+    if (error) {
+      console.error('Failed to update folder:', error)
+      return
     }
-
-    set({ collections, groups: allGroups, requests: allRequests })
+    set((state) => {
+      const folders = state.folders.map((item) => item.id === folderId ? { ...item, collapsed } : item)
+      return deriveFoldersState(folders)
+    })
   },
 
   toggleGroupCollapsed: async (groupId: string) => {
-    const group = get().groups.find((g) => g.id === groupId)
-    if (!group) return
-    const newCollapsed = !group.collapsed
-    const api = window.api
-    const { error } = await api.groups.update({ id: groupId, collapsed: newCollapsed })
-    if (error) {
-      console.error('Failed to update group:', error)
-      return
-    }
-    set((state) => ({
-      groups: state.groups.map((g) => (g.id === groupId ? { ...g, collapsed: newCollapsed } : g)),
-    }))
+    await get().toggleFolderCollapsed(groupId)
   },
 
   toggleCollectionCollapsed: async (collectionId: string) => {
-    const collection = get().collections.find((c) => c.id === collectionId)
-    if (!collection) return
-    const newCollapsed = !collection.collapsed
-    const { error } = await window.api.collections.update({ id: collectionId, collapsed: newCollapsed })
-    if (error) {
-      console.error('Failed to update collection:', error)
-      return
-    }
-    set((state) => ({
-      collections: state.collections.map((c) =>
-        c.id === collectionId ? { ...c, collapsed: newCollapsed } : c
-      ),
-    }))
+    await get().toggleFolderCollapsed(collectionId)
   },
 
   toggleSourceHidden: (source: CollectionSource) => {
     set((state) => {
       const next = new Set(state.hiddenSources)
-      if (next.has(source)) {
-        next.delete(source)
-      } else {
-        next.add(source)
-      }
+      if (next.has(source)) next.delete(source)
+      else next.add(source)
       return { hiddenSources: next }
     })
   },
 
   setSearchQuery: (q: string) => set({ searchQuery: q }),
 
-  createGroup: async (collectionId: string, name: string) => {
-    const api = window.api
-    const { data, error } = await api.groups.create({ collectionId, name })
+  createSubFolder: async (parentId: string, name: string) => {
+    const { data, error } = await window.api.folders.create({ parentId, name, source: 'local' })
     if (error) {
-      console.error('Failed to create group:', error)
+      console.error('Failed to create folder:', error)
       return null
     }
-    const group = normalizeGroup(data as Record<string, unknown>)
-    set((state) => ({ groups: [...state.groups, group] }))
-    return group.id
+    const folder = normalizeFolder(data as Record<string, unknown>)
+    set((state) => {
+      const folders = [...state.folders, folder]
+      return deriveFoldersState(folders)
+    })
+    return folder.id
   },
 
-  deleteCollection: async (id: string, commitMessage?: string) => {
-    const api = window.api
-    const { error } = await api.collections.delete({ id, commitMessage })
-    if (error) { console.error('Failed to delete collection:', error); return }
-    set((state) => ({
-      collections: state.collections.filter((c) => c.id !== id),
-      groups: state.groups.filter((g) => g.collectionId !== id),
-    }))
-  },
-
-  renameCollection: async (id: string, name: string) => {
-    const api = window.api
-    const { error } = await api.collections.rename({ id, name })
-    if (error) { console.error('Failed to rename collection:', error); return }
-    set((state) => ({
-      collections: state.collections.map((c) => c.id === id ? { ...c, name } : c),
-    }))
-  },
-
-  addRequestToCollection: async (collectionId: string) => {
-    const api = window.api
-    // reuse an existing group or auto-create a "Default" one
-    let group = get().groups.find((g) => g.collectionId === collectionId)
-    if (!group) {
-      const { data, error } = await api.groups.create({ collectionId, name: 'Default' })
-      if (error) { console.error('Failed to create default group:', error); return }
-      const newGroup = normalizeGroup(data as Record<string, unknown>)
-      group = newGroup
-      set((state) => ({ groups: [...state.groups, newGroup] }))
+  createRootFolder: async (name: string, source = 'local', integrationId?: string) => {
+    const { data, error } = await window.api.folders.create({ name, source, integrationId })
+    if (error) {
+      console.error('Failed to create collection:', error)
+      return null
     }
-    const { data, error } = await api.requests.create({ groupId: group.id, name: 'New Request', method: 'GET' })
-    if (error) { console.error('Failed to create request:', error); return }
-    const req = normalizeRequest(data as Record<string, unknown>)
-    set((state) => ({ requests: [...state.requests, req] }))
+    const folder = normalizeFolder(data as Record<string, unknown>)
+    set((state) => {
+      const folders = [...state.folders, folder]
+      return deriveFoldersState(folders)
+    })
+    return folder.id
   },
 
-  createLocalRequest: async (groupId: string) => {
-    const api = window.api
-    const { data, error } = await api.requests.create({ groupId, name: 'New Request', method: 'GET' })
+  createGroup: async (parentId: string, name: string) => get().createSubFolder(parentId, name),
+
+  addRequestToFolder: async (folderId: string) => {
+    const { data, error } = await window.api.requests.create({ folderId, name: 'New Request', method: 'GET' })
     if (error) {
       console.error('Failed to create request:', error)
       return
     }
-    const req = normalizeRequest(data as Record<string, unknown>)
-    set((state) => ({ requests: [...state.requests, req] }))
+    const request = normalizeRequest(data as Record<string, unknown>)
+    set((state) => ({ requests: [...state.requests, request] }))
+  },
+
+  addRequestToCollection: async (collectionId: string) => {
+    await get().addRequestToFolder(collectionId)
+  },
+
+  deleteCollection: async (id: string, commitMessage?: string) => {
+    const { error } = await window.api.folders.delete({ id, commitMessage })
+    if (error) {
+      console.error('Failed to delete collection:', error)
+      return
+    }
+    set((state) => {
+      const folderIds = getDescendantFolderIds(state.folders, id)
+      const folders = state.folders.filter((folder) => !folderIds.has(folder.id))
+      return {
+        ...deriveFoldersState(folders),
+        requests: state.requests.filter((request) => !folderIds.has(request.folderId)),
+      }
+    })
+  },
+
+  renameCollection: async (id: string, name: string) => {
+    const { error } = await window.api.folders.rename({ id, name })
+    if (error) {
+      console.error('Failed to rename collection:', error)
+      return
+    }
+    set((state) => {
+      const folders = state.folders.map((folder) => folder.id === id ? { ...folder, name } : folder)
+      return deriveFoldersState(folders)
+    })
   },
 
   deleteRequest: async (id: string) => {
-    const api = window.api
-    const { error } = await api.requests.delete({ id })
-    if (error) { console.error('Failed to delete request:', error); return }
-    set((state) => ({ requests: state.requests.filter((r) => r.id !== id) }))
+    const { error } = await window.api.requests.delete({ id })
+    if (error) {
+      console.error('Failed to delete request:', error)
+      return
+    }
+    set((state) => ({ requests: state.requests.filter((request) => request.id !== id) }))
   },
 
   markDirty: (requestId: string) => {
-    const api = window.api
-    api.requests.markDirty({ id: requestId, isDirty: true })
+    window.api.requests.markDirty({ id: requestId, isDirty: true })
     set((state) => ({
-      requests: state.requests.map((r) => (r.id === requestId ? { ...r, isDirty: true } : r)),
+      requests: state.requests.map((request) => request.id === requestId ? { ...request, isDirty: true } : request),
     }))
   },
 
   syncRequest: (request: Request) => {
     set((state) => ({
-      requests: state.requests.map((r) => (r.id === request.id ? { ...r, ...request } : r)),
+      requests: state.requests.map((item) => item.id === request.id ? { ...item, ...request } : item),
     }))
   },
 
   clearDirtyForCollection: (collectionId: string) => {
     set((state) => {
-      const groupIds = new Set(state.groups.filter((g) => g.collectionId === collectionId).map((g) => g.id))
+      const folderIds = getDescendantFolderIds(state.folders, collectionId)
       return {
-        requests: state.requests.map((r) => groupIds.has(r.groupId) ? { ...r, isDirty: false } : r),
+        requests: state.requests.map((request) => folderIds.has(request.folderId) ? { ...request, isDirty: false } : request),
       }
     })
   },
 
-  updateCollection: async (id: string, updates: { name?: string; description?: string; authType?: AuthType; authConfig?: Record<string, string>; sslVerification?: SslVerification; collapsed?: boolean }) => {
-    const api = window.api
-    const { error } = await api.collections.update({ id, ...updates })
-    if (error) { console.error('Failed to update collection:', error); return }
-    set((state) => ({
-      collections: state.collections.map((c) =>
-        c.id === id ? { ...c, ...updates } : c
-      ),
-    }))
+  updateCollection: async (id, updates) => {
+    const { error } = await window.api.folders.update({ id, ...updates })
+    if (error) {
+      console.error('Failed to update collection:', error)
+      return
+    }
+    set((state) => {
+      const folders = state.folders.map((folder) => folder.id === id ? { ...folder, ...updates } : folder)
+      return deriveFoldersState(folders)
+    })
   },
 
-  updateGroup: async (id: string, updates: { name?: string; description?: string; authType?: AuthType; authConfig?: Record<string, string>; sslVerification?: SslVerification }) => {
-    const api = window.api
-    const { error } = await api.groups.update({ id, ...updates })
-    if (error) { console.error('Failed to update group:', error); return }
-    set((state) => ({
-      groups: state.groups.map((g) =>
-        g.id === id ? { ...g, ...updates } : g
-      ),
-    }))
+  updateGroup: async (id, updates) => {
+    const { error } = await window.api.folders.update({ id, ...updates })
+    if (error) {
+      console.error('Failed to update folder:', error)
+      return
+    }
+    set((state) => {
+      const folders = state.folders.map((folder) => folder.id === id ? { ...folder, ...updates } : folder)
+      return deriveFoldersState(folders)
+    })
   },
 
   deleteGroup: async (id: string) => {
-    const api = window.api
-    const { error } = await api.groups.delete({ id })
-    if (error) { console.error('Failed to delete group:', error); return }
-    set((state) => ({
-      groups: state.groups.filter((g) => g.id !== id),
-      requests: state.requests.filter((r) => r.groupId !== id),
-    }))
+    const { error } = await window.api.folders.delete({ id })
+    if (error) {
+      console.error('Failed to delete folder:', error)
+      return
+    }
+    set((state) => {
+      const folderIds = getDescendantFolderIds(state.folders, id)
+      const folders = state.folders.filter((folder) => !folderIds.has(folder.id))
+      return {
+        ...deriveFoldersState(folders),
+        requests: state.requests.filter((request) => !folderIds.has(request.folderId)),
+      }
+    })
   },
 
   renameGroup: async (id: string, name: string) => {
-    const api = window.api
-    const { error } = await api.groups.update({ id, name })
-    if (error) { console.error('Failed to rename group:', error); return }
-    set((state) => ({
-      groups: state.groups.map((g) => g.id === id ? { ...g, name } : g),
-    }))
+    const { error } = await window.api.folders.rename({ id, name })
+    if (error) {
+      console.error('Failed to rename folder:', error)
+      return
+    }
+    set((state) => {
+      const folders = state.folders.map((folder) => folder.id === id ? { ...folder, name } : folder)
+      return deriveFoldersState(folders)
+    })
   },
 
-  moveRequestToGroup: async (requestId: string, newGroupId: string, insertBeforeId: string | null) => {
+  createLocalRequest: async (folderId: string) => {
+    await get().addRequestToFolder(folderId)
+  },
+
+  moveRequestToFolder: async (requestId: string, newFolderId: string, insertBeforeId: string | null) => {
     const state = get()
-    const req = state.requests.find((r) => r.id === requestId)
-    if (!req) return
-    const oldGroupId = req.groupId
+    const request = state.requests.find((item) => item.id === requestId)
+    if (!request) return
+    const oldFolderId = request.folderId
 
-    const targetReqs = state.requests
-      .filter((r) => r.groupId === newGroupId && r.id !== requestId)
+    const targetRequests = state.requests
+      .filter((item) => item.folderId === newFolderId && item.id !== requestId)
       .sort((a, b) => a.sortOrder - b.sortOrder)
-    const insertIdx = insertBeforeId ? targetReqs.findIndex((r) => r.id === insertBeforeId) : targetReqs.length
-    const finalIdx = insertIdx === -1 ? targetReqs.length : insertIdx
-    targetReqs.splice(finalIdx, 0, { ...req, groupId: newGroupId })
+    const insertIdx = insertBeforeId ? targetRequests.findIndex((item) => item.id === insertBeforeId) : targetRequests.length
+    const finalIdx = insertIdx === -1 ? targetRequests.length : insertIdx
+    targetRequests.splice(finalIdx, 0, { ...request, folderId: newFolderId })
 
-    const sourceReqs = oldGroupId !== newGroupId
-      ? state.requests.filter((r) => r.groupId === oldGroupId && r.id !== requestId).sort((a, b) => a.sortOrder - b.sortOrder)
+    const sourceRequests = oldFolderId !== newFolderId
+      ? state.requests.filter((item) => item.folderId === oldFolderId && item.id !== requestId).sort((a, b) => a.sortOrder - b.sortOrder)
       : []
 
-    set((s) => ({
-      requests: s.requests.map((r) => {
-        const tIdx = targetReqs.findIndex((x) => x.id === r.id)
-        if (tIdx !== -1) return { ...r, groupId: newGroupId, sortOrder: tIdx }
-        const sIdx = sourceReqs.findIndex((x) => x.id === r.id)
-        if (sIdx !== -1) return { ...r, sortOrder: sIdx }
-        return r
+    set((current) => ({
+      requests: current.requests.map((item) => {
+        const targetIdx = targetRequests.findIndex((candidate) => candidate.id === item.id)
+        if (targetIdx !== -1) return { ...item, folderId: newFolderId, sortOrder: targetIdx }
+        const sourceIdx = sourceRequests.findIndex((candidate) => candidate.id === item.id)
+        if (sourceIdx !== -1) return { ...item, sortOrder: sourceIdx }
+        return item
       }),
     }))
 
     const updates = [
-      ...targetReqs.map((r, i) => ({ id: r.id, sortOrder: i, newParentId: newGroupId })),
-      ...sourceReqs.map((r, i) => ({ id: r.id, sortOrder: i })),
+      ...targetRequests.map((item, index) => ({ id: item.id, sortOrder: index, newParentId: newFolderId })),
+      ...sourceRequests.map((item, index) => ({ id: item.id, sortOrder: index })),
     ]
     await window.api.reorder({ type: 'request', updates })
   },
 
-  moveGroupToCollection: async (groupId: string, newCollectionId: string, insertBeforeId: string | null) => {
+  moveRequestToGroup: async (requestId, newFolderId, insertBeforeId) => {
+    await get().moveRequestToFolder(requestId, newFolderId, insertBeforeId)
+  },
+
+  moveFolder: async (folderId: string, newParentId: string | null, insertBeforeId: string | null) => {
     const state = get()
-    const grp = state.groups.find((g) => g.id === groupId)
-    if (!grp) return
-    const oldCollectionId = grp.collectionId
+    const folder = state.folders.find((item) => item.id === folderId)
+    if (!folder) return
+    const oldParentId = folder.parentId ?? null
 
-    const targetGroups = state.groups
-      .filter((g) => g.collectionId === newCollectionId && g.id !== groupId)
+    const targetFolders = state.folders
+      .filter((item) => (item.parentId ?? null) === newParentId && item.id !== folderId)
       .sort((a, b) => a.sortOrder - b.sortOrder)
-    const insertIdx = insertBeforeId ? targetGroups.findIndex((g) => g.id === insertBeforeId) : targetGroups.length
-    const finalIdx = insertIdx === -1 ? targetGroups.length : insertIdx
-    targetGroups.splice(finalIdx, 0, { ...grp, collectionId: newCollectionId })
+    const insertIdx = insertBeforeId ? targetFolders.findIndex((item) => item.id === insertBeforeId) : targetFolders.length
+    const finalIdx = insertIdx === -1 ? targetFolders.length : insertIdx
+    targetFolders.splice(finalIdx, 0, { ...folder, parentId: newParentId ?? undefined })
 
-    const sourceGroups = oldCollectionId !== newCollectionId
-      ? state.groups.filter((g) => g.collectionId === oldCollectionId && g.id !== groupId).sort((a, b) => a.sortOrder - b.sortOrder)
+    const sourceFolders = oldParentId !== newParentId
+      ? state.folders.filter((item) => (item.parentId ?? null) === oldParentId && item.id !== folderId).sort((a, b) => a.sortOrder - b.sortOrder)
       : []
 
-    set((s) => ({
-      groups: s.groups.map((g) => {
-        const tIdx = targetGroups.findIndex((x) => x.id === g.id)
-        if (tIdx !== -1) return { ...g, collectionId: newCollectionId, sortOrder: tIdx }
-        const sIdx = sourceGroups.findIndex((x) => x.id === g.id)
-        if (sIdx !== -1) return { ...g, sortOrder: sIdx }
-        return g
-      }),
-    }))
+    set((current) => {
+      const folders = current.folders.map((item) => {
+        const targetIdx = targetFolders.findIndex((candidate) => candidate.id === item.id)
+        if (targetIdx !== -1) return { ...item, parentId: newParentId ?? undefined, sortOrder: targetIdx }
+        const sourceIdx = sourceFolders.findIndex((candidate) => candidate.id === item.id)
+        if (sourceIdx !== -1) return { ...item, sortOrder: sourceIdx }
+        return item
+      })
+      return deriveFoldersState(folders)
+    })
 
     const updates = [
-      ...targetGroups.map((g, i) => ({ id: g.id, sortOrder: i, newParentId: newCollectionId })),
-      ...sourceGroups.map((g, i) => ({ id: g.id, sortOrder: i })),
+      ...targetFolders.map((item, index) => ({ id: item.id, sortOrder: index, newParentId: newParentId ?? undefined })),
+      ...sourceFolders.map((item, index) => ({ id: item.id, sortOrder: index })),
     ]
-    await window.api.reorder({ type: 'group', updates })
+    await window.api.reorder({ type: 'folder', updates })
+  },
+
+  moveGroupToCollection: async (folderId, newParentId, insertBeforeId) => {
+    await get().moveFolder(folderId, newParentId, insertBeforeId)
   },
 
   moveCollectionToSource: async (collectionId: string, newSource: CollectionSource) => {
-    set((s) => ({
-      collections: s.collections.map((c) => c.id === collectionId ? { ...c, source: newSource } : c),
-    }))
-    await window.api.collections.moveSource({ id: collectionId, source: newSource })
+    set((state) => {
+      const folders = state.folders.map((folder) => folder.id === collectionId ? { ...folder, source: newSource } : folder)
+      return deriveFoldersState(folders)
+    })
+    await window.api.folders.moveSource({ id: collectionId, source: newSource })
   },
 }))

--- a/src/renderer/src/store/collections.ts
+++ b/src/renderer/src/store/collections.ts
@@ -76,21 +76,18 @@ export const useCollectionsStore = create<CollectionsState>((set, get) => ({
       return
     }
 
+    const { data: reqData, error: reqError } = await window.api.requests.listAll()
+    if (reqError) {
+      console.error('Failed to load requests:', reqError)
+      return
+    }
+
     const folders = (data as Record<string, unknown>[]).map(normalizeFolder)
-    const requestResults = await Promise.all(
-      folders.map(async (folder) => {
-        const result = await window.api.requests.list({ folderId: folder.id })
-        if (result.error) {
-          console.error(`Failed to load requests for folder ${folder.id}:`, result.error)
-          return [] as Request[]
-        }
-        return ((result.data ?? []) as Record<string, unknown>[]).map(normalizeRequest)
-      })
-    )
+    const requests = ((reqData ?? []) as Record<string, unknown>[]).map(normalizeRequest)
 
     set({
       ...deriveFoldersState(folders),
-      requests: requestResults.flat(),
+      requests,
     })
   },
 
@@ -354,7 +351,7 @@ export const useCollectionsStore = create<CollectionsState>((set, get) => ({
     })
 
     const updates = [
-      ...targetFolders.map((item, index) => ({ id: item.id, sortOrder: index, newParentId: newParentId ?? undefined })),
+      ...targetFolders.map((item, index) => ({ id: item.id, sortOrder: index, newParentId: newParentId })),
       ...sourceFolders.map((item, index) => ({ id: item.id, sortOrder: index })),
     ]
     await window.api.reorder({ type: 'folder', updates })

--- a/src/renderer/src/store/requests.ts
+++ b/src/renderer/src/store/requests.ts
@@ -80,6 +80,14 @@ function clearUndo(): void {
   if (undoPushTimer) { clearTimeout(undoPushTimer); undoPushTimer = null }
 }
 
+function getRootCollectionId(folderId: string, folders: Array<{ id: string; parentId?: string }>): string | null {
+  let current = folders.find((folder) => folder.id === folderId)
+  while (current?.parentId) {
+    current = folders.find((folder) => folder.id === current?.parentId)
+  }
+  return current?.id ?? null
+}
+
 function isEqualToSaved(a: Request, b: Request): boolean {
   for (const field of DIRTY_FIELDS) {
     const av = a[field]
@@ -234,7 +242,7 @@ export const useRequestsStore = create<RequestsState>((set, get) => ({
       authType: editingRequest.authType,
       authConfig: editingRequest.authConfig,
       sslVerification: editingRequest.sslVerification,
-      groupId: editingRequest.groupId,
+      folderId: editingRequest.folderId,
     }
     httpRequest.params = kvpToRecord(editingRequest.params)
 
@@ -294,9 +302,9 @@ export const useRequestsStore = create<RequestsState>((set, get) => ({
     useCollectionsStore.getState().syncRequest(saved)
 
     // For git-sourced collections, mark the request as uncommitted to git
-    const { groups, collections, markDirty } = useCollectionsStore.getState()
-    const group = groups.find((g) => g.id === editingRequest.groupId)
-    const collection = group ? collections.find((c) => c.id === group.collectionId) : null
+    const { folders, collections, markDirty } = useCollectionsStore.getState()
+    const collectionId = getRootCollectionId(editingRequest.folderId, folders)
+    const collection = collectionId ? collections.find((item) => item.id === collectionId) : null
     if (['git', 'github', 'gitlab'].includes(collection?.source ?? '')) {
       markDirty(editingRequest.id)
     }
@@ -317,7 +325,7 @@ export const useRequestsStore = create<RequestsState>((set, get) => ({
     // Normalise snake_case DB row to camelCase Request
     const saved: Request = {
       id: data.id as string,
-      groupId: data.group_id as string,
+      folderId: data.folder_id as string,
       name: data.name as string,
       protocol: (data.protocol as Request['protocol']) ?? 'http',
       method: data.method as Request['method'],

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -26,8 +26,9 @@ export interface KeyValuePair {
   fieldType?: 'text' | 'file'
 }
 
-export interface Collection {
+export interface Folder {
   id: string
+  parentId?: string
   name: string
   description?: string
   source: CollectionSource
@@ -36,10 +37,14 @@ export interface Collection {
   authType: AuthType
   authConfig: Record<string, string>
   sslVerification: SslVerification
+  hidden: boolean
   collapsed: boolean
+  sortOrder: number
   createdAt: number
   updatedAt: number
 }
+
+export type Collection = Folder
 
 export interface Integration {
   id: string
@@ -59,22 +64,11 @@ export interface Integration {
   updatedAt: number
 }
 
-export interface Group {
-  id: string
-  collectionId: string
-  name: string
-  description?: string
-  collapsed: boolean
-  hidden: boolean
-  sortOrder: number
-  authType: AuthType
-  authConfig: Record<string, string>
-  sslVerification: SslVerification
-}
+export type Group = Folder
 
 export interface Request {
   id: string
-  groupId: string
+  folderId: string
   name: string
   protocol: ProtocolType
   method: HttpMethod
@@ -146,7 +140,7 @@ export interface HttpRequest {
   authType: AuthType
   authConfig: Record<string, string>
   sslVerification?: SslVerification
-  groupId?: string
+  folderId?: string
 }
 
 export interface HttpResponse {


### PR DESCRIPTION
## Summary

Replaces the fixed two-level `collections → groups → requests` hierarchy with a unified `folders` table supporting infinite nesting. Requests can now be created at any folder level — root or any depth below.

Closes #100

## What changed

### Architecture
- **New `folders` table** — `parent_id IS NULL` = root folder (what users see as a "collection"), `parent_id = <id>` = sub-folder at any depth
- **`requests.folder_id`** replaces `requests.group_id` — requests belong to any folder, not just groups
- **DB migration** — existing `collections` and `groups` are automatically migrated to `folders` with the same IDs; no data loss

### Backend (main process)
- New `postly:folders:*` IPC handlers (list, create, rename, update, delete, move-source)
- `requests:create` / `requests:list` now accept `folderId`
- All services updated: github, gitlab, git-local, backstage, openapi-parser
- **Auth/SSL inheritance** fixed to walk the full ancestor chain — previously only checked the direct folder and root, skipping any intermediate folders (bug for 3+ levels)

### Export / Import
- Recursive folder tree export format
- **Full backward compatibility** with old `groups`-based exports — importer falls back to `groups` when `folders` key is absent
- git-local sync fixed: old `.postly.json` files using `groups` were silently losing all requests on sync

### Frontend (renderer)
- `Folder` type replaces `Collection` + `Group` (both kept as aliases for compatibility)
- `Request.folderId` replaces `groupId`
- Zustand store loads flat folder list and computes the tree
- Sidebar (`GroupSection`) now renders **recursively** — root folders show as collections, sub-folders show as collapsible groups, requests appear at any level

## Tests
- 432/432 unit tests passing
- New export/import tests covering new format (requests at root, 3-level nesting, auth config) and old format (single group, multiple groups, `folders` preferred over `groups` when both present)