### PR TITLE
fix(oauth): validate state in waitForRedirect to prevent state mismatch

### DIFF
--- a/src/main/services/__tests__/oauth.integration.test.ts
+++ b/src/main/services/__tests__/oauth.integration.test.ts
@@ -448,11 +448,14 @@ describe('authorizeAuthCode — state validation', () => {
     decoyUrls,
     decoyEventName = 'will-redirect',
     callbackEventName = 'will-redirect',
+    onDecoyEvent,
   }: {
     /** URLs to fire as decoy events before the real callback. */
     decoyUrls: (redirectOrigin: string) => string[]
     decoyEventName?: 'will-redirect' | 'will-navigate'
     callbackEventName?: 'will-redirect' | 'will-navigate'
+    /** Called with each decoy's event object so callers can assert on it. */
+    onDecoyEvent?: (event: { preventDefault: ReturnType<typeof vi.fn> }) => void
   }) {
     return function (this: unknown) {
       const wcListeners: Record<
@@ -481,9 +484,9 @@ describe('authorizeAuthCode — state validation', () => {
           // Fire decoy events first, each 20 ms apart.
           decoys.forEach((decoyUrl, i) => {
             setTimeout(() => {
-              wcListeners[decoyEventName]?.forEach((fn) =>
-                fn({ preventDefault: vi.fn() }, decoyUrl),
-              )
+              const event = { preventDefault: vi.fn() }
+              onDecoyEvent?.(event)
+              wcListeners[decoyEventName]?.forEach((fn) => fn(event, decoyUrl))
             }, 20 * (i + 1))
           })
 
@@ -638,5 +641,83 @@ describe('authorizeAuthCode — state validation', () => {
     const [statements] = vi.mocked(runTransaction).mock.calls[0]
     const insert = statements.find((s) => s.sql.includes('INSERT INTO tokens'))
     expect(insert?.params).toEqual(expect.arrayContaining(['integration-access-token']))
+  })
+
+  it('ignores will-navigate decoys but resolves when the real callback comes via will-redirect', async () => {
+    // Symmetric counterpart of the "will-redirect decoys → will-navigate real" test.
+    // Ensures the state check applies to will-navigate events too.
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [`${origin}/callback?code=nav_decoy&state=stale-nav-state`],
+        decoyEventName: 'will-navigate',
+        callbackEventName: 'will-redirect',
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(token.accessToken).toBe('integration-access-token')
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    expect(parseFormBody(calls[0].body ?? '')['code']).toBe('integration-auth-code')
+  })
+
+  it('does not call event.preventDefault() on decoy events — IDP intermediate navigations are not blocked', async () => {
+    // If preventDefault were called on a decoy the IDP's own login-form POST or
+    // consent-page navigation would be blocked and the user could never complete auth.
+    const decoyEvents: Array<{ preventDefault: ReturnType<typeof vi.fn> }> = []
+
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [
+          `${origin}/callback?code=decoy1&state=wrong-state`,
+          `${origin}/callback?code=decoy2`,
+        ],
+        onDecoyEvent: (evt) => decoyEvents.push(evt),
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(decoyEvents).toHaveLength(2)
+    for (const evt of decoyEvents) {
+      expect(evt.preventDefault).not.toHaveBeenCalled()
+    }
+  })
+
+  it('authorizeInline skips decoys and completes the full flow end-to-end', async () => {
+    // The bug was reported on the inline OAuth path ("root folder" collection auth),
+    // which calls authorizeAuthCode with a config whose id is a hash of the config
+    // fields. This test exercises the full authorizeInline → authorizeAuthCode →
+    // waitForRedirect chain with a decoy to confirm state validation fires there too.
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [`${origin}/callback?code=inline_decoy&state=stale-inline-state`],
+      }),
+    )
+    const { authorizeInline } = await import('../oauth')
+
+    const inlineConfig: OAuthConfig = {
+      id: '',
+      name: 'inline',
+      grantType: 'authorization_code',
+      clientId: 'inline-client',
+      clientSecret: 'inline-secret',
+      authUrl: 'http://127.0.0.1:1/authorize',
+      tokenUrl: `${server.httpBase}/oauth2/token`,
+      scopes: 'openid profile',
+      redirectUri: 'http://localhost:19999/callback',
+    }
+
+    const token = await authorizeInline(inlineConfig)
+
+    expect(token.accessToken).toBe('integration-access-token')
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    expect(calls).toHaveLength(1)
+    expect(parseFormBody(calls[0].body ?? '')['code']).toBe('integration-auth-code')
+    // The token's oauthConfigId must be the config hash, not the empty id.
+    expect(token.oauthConfigId).toHaveLength(32)
+    expect(token.oauthConfigId).not.toBe('')
   })
 })

--- a/src/main/services/__tests__/oauth.integration.test.ts
+++ b/src/main/services/__tests__/oauth.integration.test.ts
@@ -11,6 +11,9 @@
  *   • The authorizeAuthCode flow reuses the same persistent session partition
  *     (`persist:oauth-<id>`) across calls so the IDP session cookie is
  *     preserved between auth attempts (no re-login).
+ *   • waitForRedirect validates the state on every captured navigation event so
+ *     that intermediate same-origin redirects with a wrong or absent state are
+ *     ignored — fixing the "OAuth state mismatch" error observed on Windows 11.
  *
  * The database layer is mocked — these tests focus purely on HTTP behaviour.
  *
@@ -18,6 +21,7 @@
  */
 
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest'
+import { BrowserWindow } from 'electron'
 import { MocklyServer } from './helpers/mockly'
 import type { OAuthConfig, Token } from '../oauth'
 
@@ -415,5 +419,224 @@ describe('authorizeAuthCode — session partition persistence', () => {
     expect(params['code_verifier']).toBeDefined()
 
     expect(token.accessToken).toBe('integration-access-token')
+  })
+})
+
+// ─── authorizeAuthCode — state validation (OAuth state mismatch fix) ──────────
+//
+// Root cause of issue #134: waitForRedirect captured the first navigation event
+// from the same origin that carried a `code` param, regardless of whether its
+// `state` matched the one generated for the current flow. On Windows 11, the IDP
+// or Chromium can fire extra will-navigate/will-redirect events during the login
+// sequence (intermediate form POSTs, consent pages, cached redirects). If any of
+// those URLs happened to contain a `code` query parameter but a different — or
+// absent — `state`, the flow resolved with the wrong state and threw "OAuth state
+// mismatch" before the real callback arrived.
+//
+// The fix validates the state inside tryCapture and skips any URL whose state
+// does not match the generated value, continuing to wait for the real callback.
+//
+// These tests simulate the exact pattern that triggered the bug: one or more
+// "decoy" navigation events that match the redirect-URI origin and carry a code
+// but the wrong (or absent) state, followed by the legitimate IDP callback with
+// the correct state. The real token exchange is completed against a live Mockly
+// server so the full code→token round-trip is exercised.
+
+describe('authorizeAuthCode — state validation', () => {
+  /** Builds a BrowserWindow constructor that fires `decoys` before the real callback. */
+  function makeWindowWithDecoys({
+    decoyUrls,
+    decoyEventName = 'will-redirect',
+    callbackEventName = 'will-redirect',
+  }: {
+    /** URLs to fire as decoy events before the real callback. */
+    decoyUrls: (redirectOrigin: string) => string[]
+    decoyEventName?: 'will-redirect' | 'will-navigate'
+    callbackEventName?: 'will-redirect' | 'will-navigate'
+  }) {
+    return function (this: unknown) {
+      const wcListeners: Record<
+        string,
+        Array<(e: { preventDefault: () => void }, url: string) => void>
+      > = {}
+      const winListeners: Record<string, Array<() => void>> = {}
+
+      const removeListener = <T>(listeners: Record<string, Array<T>>, event: string, handler: T) => {
+        const list = listeners[event]
+        if (!list) return
+        const idx = list.indexOf(handler)
+        if (idx !== -1) list.splice(idx, 1)
+      }
+
+      return {
+        loadURL: vi.fn().mockImplementation((url: string) => {
+          const authUrl = new URL(url)
+          const redirectUri = authUrl.searchParams.get('redirect_uri')
+          const correctState = authUrl.searchParams.get('state')
+          if (!redirectUri) return
+
+          const redirectOrigin = new URL(redirectUri).origin
+          const decoys = decoyUrls(redirectOrigin)
+
+          // Fire decoy events first, each 20 ms apart.
+          decoys.forEach((decoyUrl, i) => {
+            setTimeout(() => {
+              wcListeners[decoyEventName]?.forEach((fn) =>
+                fn({ preventDefault: vi.fn() }, decoyUrl),
+              )
+            }, 20 * (i + 1))
+          })
+
+          // Fire the real callback with the correct code and state after all decoys.
+          setTimeout(() => {
+            const cb = new URL(redirectUri)
+            cb.searchParams.set('code', 'integration-auth-code')
+            if (correctState) cb.searchParams.set('state', correctState)
+            wcListeners[callbackEventName]?.forEach((fn) =>
+              fn({ preventDefault: vi.fn() }, cb.toString()),
+            )
+          }, 20 * (decoys.length + 1) + 30)
+        }),
+        webContents: {
+          on: vi.fn().mockImplementation(
+            (event: string, handler: (e: { preventDefault: () => void }, url: string) => void) => {
+              ;(wcListeners[event] ??= []).push(handler)
+            },
+          ),
+          off: vi.fn().mockImplementation(
+            (event: string, handler: (e: { preventDefault: () => void }, url: string) => void) => {
+              removeListener(wcListeners, event, handler)
+            },
+          ),
+        },
+        on: vi.fn().mockImplementation((event: string, handler: () => void) => {
+          ;(winListeners[event] ??= []).push(handler)
+        }),
+        off: vi.fn().mockImplementation((event: string, handler: () => void) => {
+          removeListener(winListeners, event, handler)
+        }),
+        isDestroyed: vi.fn().mockReturnValue(false),
+        close: vi.fn(),
+      }
+    }
+  }
+
+  const AUTH_CONFIG: OAuthConfig = {
+    id: 'state-validation-config',
+    name: 'State Validation Test',
+    grantType: 'authorization_code',
+    clientId: 'state-client',
+    scopes: 'openid',
+    authUrl: 'http://127.0.0.1:1/authorize',
+    tokenUrl: '',
+    redirectUri: 'http://localhost:19999/callback',
+  }
+
+  beforeEach(() => {
+    AUTH_CONFIG.tokenUrl = `${server.httpBase}/oauth2/token`
+  })
+
+  it('ignores a will-redirect with a wrong state and resolves on the real callback', async () => {
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [`${origin}/callback?code=decoy_code&state=completely-wrong-state`],
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(token.accessToken).toBe('integration-access-token')
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    // Only the real code (not the decoy) must reach the token endpoint.
+    expect(parseFormBody(calls[0].body ?? '')['code']).toBe('integration-auth-code')
+  })
+
+  it('ignores a will-redirect with no state param and resolves on the real callback', async () => {
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        // No `state` param at all — simulates an IDP that omits state on intermediate redirects.
+        decoyUrls: (origin) => [`${origin}/callback?code=stateless_code`],
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(token.accessToken).toBe('integration-access-token')
+  })
+
+  it('ignores a will-navigate with a wrong state and resolves on the real callback', async () => {
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [`${origin}/callback?code=nav_decoy&state=bad-state`],
+        decoyEventName: 'will-navigate',
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(token.accessToken).toBe('integration-access-token')
+  })
+
+  it('ignores multiple decoy events in a row before the correct callback arrives', async () => {
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [
+          `${origin}/callback?code=decoy1&state=wrong-1`,
+          `${origin}/other-path?code=decoy2&state=wrong-2`,
+          `${origin}/callback?code=decoy3`,
+        ],
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(token.accessToken).toBe('integration-access-token')
+    const { calls } = await server.getCalls(TOKEN_MOCK_ID)
+    expect(calls).toHaveLength(1)
+    expect(parseFormBody(calls[0].body ?? '')['code']).toBe('integration-auth-code')
+  })
+
+  it('ignores will-redirect decoys but resolves when the real callback comes via will-navigate', async () => {
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [`${origin}/callback?code=redirect_decoy&state=stale-state`],
+        decoyEventName: 'will-redirect',
+        callbackEventName: 'will-navigate',
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    expect(token.accessToken).toBe('integration-access-token')
+  })
+
+  it('completes the full code exchange and persists the token after skipping decoys', async () => {
+    const { runTransaction } = await import('../../database')
+    vi.mocked(BrowserWindow).mockImplementationOnce(
+      makeWindowWithDecoys({
+        decoyUrls: (origin) => [
+          `${origin}/callback?code=ignored_code&state=stale`,
+        ],
+      }),
+    )
+    const { authorizeAuthCode } = await import('../oauth')
+
+    const token = await authorizeAuthCode({ ...AUTH_CONFIG })
+
+    // Token fields from Mockly response.
+    expect(token.accessToken).toBe('integration-access-token')
+    expect(token.tokenType).toBe('Bearer')
+    expect(token.refreshToken).toBe('integration-refresh-token')
+
+    // Database transaction must have been called to persist the token.
+    expect(vi.mocked(runTransaction)).toHaveBeenCalled()
+    const [statements] = vi.mocked(runTransaction).mock.calls[0]
+    const insert = statements.find((s) => s.sql.includes('INSERT INTO tokens'))
+    expect(insert?.params).toEqual(expect.arrayContaining(['integration-access-token']))
   })
 })

--- a/src/main/services/__tests__/oauth.test.ts
+++ b/src/main/services/__tests__/oauth.test.ts
@@ -459,6 +459,147 @@ describe('OAuth integration', () => {
 
       await expect(authorizeAuthCode(cfg())).rejects.toThrow('Authorization window closed')
     })
+
+    // ── state validation (issue #134 — OAuth state mismatch on Windows 11) ──
+    //
+    // waitForRedirect must skip any navigation event that carries a `code` from
+    // the expected origin but a wrong or absent `state`. Only the event whose
+    // `state` matches the generated value should resolve the promise.
+
+    it('ignores a will-redirect from the same origin that has a code but wrong state', async () => {
+      vi.mocked(BrowserWindow).mockImplementationOnce(function () {
+        const wcListeners: Record<string, Array<(e: { preventDefault: () => void }, url: string) => void>> = {}
+        const winListeners: Record<string, Array<() => void>> = {}
+        return {
+          loadURL: vi.fn().mockImplementation((url: string) => {
+            const authUrl = new URL(url)
+            const redirectUri = authUrl.searchParams.get('redirect_uri')
+            const correctState = authUrl.searchParams.get('state')
+            if (!redirectUri) return
+            const origin = new URL(redirectUri).origin
+
+            // Decoy: same origin, has code, but wrong state
+            setTimeout(() => {
+              const decoy = `${origin}/callback?code=decoy_code&state=totally-wrong-state`
+              wcListeners['will-redirect']?.forEach((fn) => fn({ preventDefault: vi.fn() }, decoy))
+            }, 20)
+
+            // Real callback: correct code and state
+            setTimeout(() => {
+              const cb = new URL(redirectUri)
+              cb.searchParams.set('code', 'fake_auth_code')
+              if (correctState) cb.searchParams.set('state', correctState)
+              wcListeners['will-redirect']?.forEach((fn) => fn({ preventDefault: vi.fn() }, cb.toString()))
+            }, 60)
+          }),
+          webContents: {
+            on: vi.fn().mockImplementation((event: string, handler: (e: { preventDefault: () => void }, url: string) => void) => {
+              ;(wcListeners[event] ??= []).push(handler)
+            }),
+            off: vi.fn(),
+          },
+          on: vi.fn().mockImplementation((event: string, handler: () => void) => {
+            ;(winListeners[event] ??= []).push(handler)
+          }),
+          off: vi.fn(),
+          isDestroyed: vi.fn().mockReturnValue(false),
+          close: vi.fn(),
+        }
+      })
+
+      const token = await authorizeAuthCode(cfg())
+      expect(token.accessToken).toBe('test_access_token')
+    })
+
+    it('ignores a will-redirect with no state param and resolves on the correct callback', async () => {
+      vi.mocked(BrowserWindow).mockImplementationOnce(function () {
+        const wcListeners: Record<string, Array<(e: { preventDefault: () => void }, url: string) => void>> = {}
+        const winListeners: Record<string, Array<() => void>> = {}
+        return {
+          loadURL: vi.fn().mockImplementation((url: string) => {
+            const authUrl = new URL(url)
+            const redirectUri = authUrl.searchParams.get('redirect_uri')
+            const correctState = authUrl.searchParams.get('state')
+            if (!redirectUri) return
+            const origin = new URL(redirectUri).origin
+
+            // Decoy: same origin, has code, NO state param at all
+            setTimeout(() => {
+              const decoy = `${origin}/callback?code=stateless_code`
+              wcListeners['will-redirect']?.forEach((fn) => fn({ preventDefault: vi.fn() }, decoy))
+            }, 20)
+
+            // Real callback
+            setTimeout(() => {
+              const cb = new URL(redirectUri)
+              cb.searchParams.set('code', 'fake_auth_code')
+              if (correctState) cb.searchParams.set('state', correctState)
+              wcListeners['will-redirect']?.forEach((fn) => fn({ preventDefault: vi.fn() }, cb.toString()))
+            }, 60)
+          }),
+          webContents: {
+            on: vi.fn().mockImplementation((event: string, handler: (e: { preventDefault: () => void }, url: string) => void) => {
+              ;(wcListeners[event] ??= []).push(handler)
+            }),
+            off: vi.fn(),
+          },
+          on: vi.fn().mockImplementation((event: string, handler: () => void) => {
+            ;(winListeners[event] ??= []).push(handler)
+          }),
+          off: vi.fn(),
+          isDestroyed: vi.fn().mockReturnValue(false),
+          close: vi.fn(),
+        }
+      })
+
+      const token = await authorizeAuthCode(cfg())
+      expect(token.accessToken).toBe('test_access_token')
+    })
+
+    it('ignores a will-navigate with wrong state and resolves when correct will-navigate fires', async () => {
+      vi.mocked(BrowserWindow).mockImplementationOnce(function () {
+        const wcListeners: Record<string, Array<(e: { preventDefault: () => void }, url: string) => void>> = {}
+        const winListeners: Record<string, Array<() => void>> = {}
+        return {
+          loadURL: vi.fn().mockImplementation((url: string) => {
+            const authUrl = new URL(url)
+            const redirectUri = authUrl.searchParams.get('redirect_uri')
+            const correctState = authUrl.searchParams.get('state')
+            if (!redirectUri) return
+            const origin = new URL(redirectUri).origin
+
+            // Decoy via will-navigate: same origin, code present, bad state
+            setTimeout(() => {
+              const decoy = `${origin}/callback?code=nav_decoy&state=stale-state-from-old-session`
+              wcListeners['will-navigate']?.forEach((fn) => fn({ preventDefault: vi.fn() }, decoy))
+            }, 20)
+
+            // Real callback via will-navigate
+            setTimeout(() => {
+              const cb = new URL(redirectUri)
+              cb.searchParams.set('code', 'fake_auth_code')
+              if (correctState) cb.searchParams.set('state', correctState)
+              wcListeners['will-navigate']?.forEach((fn) => fn({ preventDefault: vi.fn() }, cb.toString()))
+            }, 60)
+          }),
+          webContents: {
+            on: vi.fn().mockImplementation((event: string, handler: (e: { preventDefault: () => void }, url: string) => void) => {
+              ;(wcListeners[event] ??= []).push(handler)
+            }),
+            off: vi.fn(),
+          },
+          on: vi.fn().mockImplementation((event: string, handler: () => void) => {
+            ;(winListeners[event] ??= []).push(handler)
+          }),
+          off: vi.fn(),
+          isDestroyed: vi.fn().mockReturnValue(false),
+          close: vi.fn(),
+        }
+      })
+
+      const token = await authorizeAuthCode(cfg())
+      expect(token.accessToken).toBe('test_access_token')
+    })
   })
 
   // ── authorizeInline ────────────────────────────────────────────────────────

--- a/src/main/services/oauth.ts
+++ b/src/main/services/oauth.ts
@@ -48,9 +48,15 @@ export interface Token {
  * registered redirect URI, intercepting the navigation event before Electron
  * tries to load the URL. This works for any URI scheme (http, https, custom)
  * without requiring a local HTTP server.
+ *
+ * Only resolves when both the `code` and the `state` in the redirect URL match
+ * the expected values. This prevents a class of state-mismatch errors on
+ * Windows where intermediate navigations from the same origin (e.g. IDP form
+ * submissions) fire `will-navigate` with a `code` param but no matching state.
  */
 async function waitForRedirect(
   redirectUri: string,
+  expectedState: string,
   win: BrowserWindow,
 ): Promise<{ code: string; state: string }> {
   const { origin: expectedOrigin } = new URL(redirectUri)
@@ -80,8 +86,11 @@ async function waitForRedirect(
         if (origin !== expectedOrigin) return
         const code = searchParams.get('code')
         if (!code) return
+        // Ignore redirects that don't carry the expected state — they are
+        // intermediate navigations within the IDP flow, not the final callback.
+        if (searchParams.get('state') !== expectedState) return
         event.preventDefault()
-        settle(() => resolve({ code, state: searchParams.get('state') ?? '' }))
+        settle(() => resolve({ code, state: expectedState }))
       } catch { /* ignore unparseable URLs */ }
     }
 
@@ -200,7 +209,7 @@ export async function authorizeAuthCode(config: OAuthConfig, sslVerification = t
   })
   // Register listener BEFORE loadURL so the redirect is caught even if
   // Keycloak completes it instantly (e.g. an existing session).
-  const redirectPromise = waitForRedirect(redirectUri, win)
+  const redirectPromise = waitForRedirect(redirectUri, state, win)
   win.loadURL(authUrl.toString())
 
   let code: string


### PR DESCRIPTION
## Root cause

`waitForRedirect` captured the first navigation event from the expected redirect-URI origin that contained a `code` param — **without checking whether the `state` matched** the one generated for the current flow.

On Windows 11, Chromium/Electron fires extra `will-navigate`/`will-redirect` events during the IDP login sequence (intermediate form POSTs, consent pages, cached session redirects). If any of those URLs happened to include a `code` query parameter with a wrong or absent `state`, the flow would resolve with the mismatched state and immediately throw **`OAuth state mismatch`**.

## Fix

Pass `expectedState` into `waitForRedirect` and validate it inside `tryCapture`. Any captured URL whose `state` does not equal the generated value is skipped; the function keeps waiting until the real IDP callback arrives with the correct state.

```ts
// Before — captured first URL with `code`, regardless of state
if (searchParams.get('state') !== expectedState) return  // ← missing

// After — skips decoys, waits for matching state
if (searchParams.get('state') !== expectedState) return
```

## Tests

**Unit (`oauth.test.ts`)** — 3 new tests:
- `will-redirect` with wrong state is ignored; correct redirect resolves
- `will-redirect` with **no state param** is ignored; correct redirect resolves
- `will-navigate` with wrong state is ignored; correct `will-navigate` resolves

**Integration (`oauth.integration.test.ts`)** — 6 new tests against a live Mockly token endpoint:
- Wrong-state decoy via `will-redirect` → real callback resolves + token exchanged
- No-state decoy → real callback resolves
- Wrong-state decoy via `will-navigate` → real callback resolves
- Multiple decoys in a row → final correct callback resolves
- `will-redirect` decoy → real callback via `will-navigate` resolves
- Full round-trip: decoy skipped, token persisted to DB

Closes #134