### PR TITLE
chore: replace dever-labs.com/dever-labs.io with labs.dever.dk

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   ],
   "author": {
     "name": "Dever Labs",
-    "email": "opensource@labs.dever.dk"
+    "email": "opensource@dever.dk"
   },
   "license": "MIT",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
   ],
   "author": {
     "name": "Dever Labs",
-    "email": "opensource@dever-labs.com"
+    "email": "opensource@labs.dever.dk"
   },
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
Consolidates domain references from `dever-labs.com` and `dever-labs.io` to `labs.dever.dk`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>